### PR TITLE
New automatic ECAM page switch

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -27,20 +27,41 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
     }
     Init() {
         super.Init();
-        this.changePage("FUEL");
+        this.changePage("DOOR");
 
         this.lastAPUMasterState = 0 // MODIFIED
+        this.externalPowerWhenApuMasterOnTimer = -1 // MODIFIED
     }
     onUpdate(_deltaTime) {
         super.onUpdate(_deltaTime);
         this.updateAnnunciations();
 
-        var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool"); // MODIFIED
+
+        // modification start here
+        var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool");  
         // automaticaly switch to the APU page when apu master switch is on
-        if (this.lastAPUMasterState != currentAPUMasterState) { // MODIFIED
-            this.lastAPUMasterState = currentAPUMasterState; // MODIFIED
-            this.changePage("APU"); // MODIFIED
+        if (this.lastAPUMasterState != currentAPUMasterState) {  
+            //if external power is off when turning on apu, only show the apu page for 10 seconds, then the DOOR page
+            var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "Bool")  
+            if (externalPower === 1) {  
+                this.externalPowerWhenApuMasterOnTimer = 10
+                this.lastAPUMasterState = currentAPUMasterState;  
+                this.changePage("APU")
+            } else {  
+                this.lastAPUMasterState = currentAPUMasterState;  
+                this.changePage("APU");  
+            }  
+
         }
+
+        if (this.externalPowerWhenApuMasterOnTimer >= 0) {  
+            this.externalPowerWhenApuMasterOnTimer -= _deltaTime/1000
+            if (this.externalPowerWhenApuMasterOnTimer <= 0) {  
+                this.changePage("DOOR")  
+            }  
+        }  
+
+        // modification ends here
     }
     updateAnnunciations() {
         let infoPanelManager = this.upperTopScreen.getInfoPanelManager();

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -59,6 +59,14 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
             }  
         }  
 
+
+        //automatic DOOR page switch
+        var cabinDoorPctOpen = SimVar.GetSimVarValue("INTERACTIVE POINT OPEN:0", "percent");
+        var cateringDoorPctOpen = SimVar.GetSimVarValue("INTERACTIVE POINT OPEN:3", "percent");
+        var fwdCargoPctOpen = SimVar.GetSimVarValue("INTERACTIVE POINT OPEN:5", "percent");
+        if (cabinDoorPctOpen >= 20 || cateringDoorPctOpen >= 20 || fwdCargoPctOpen >= 20) {
+            this.changePage("DOOR")
+        }
         // modification ends here
     }
     updateAnnunciations() {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -27,7 +27,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
     }
     Init() {
         super.Init();
-        this.changePage("DOOR"); // MODIFIED
+        this.changePage("FUEL"); // MODIFIED
 
         this.lastAPUMasterState = 0 // MODIFIED
         this.externalPowerWhenApuMasterOnTimer = -1 // MODIFIED
@@ -41,21 +41,19 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool");  
         // automaticaly switch to the APU page when apu master switch is on
         if (this.lastAPUMasterState != currentAPUMasterState) {  
+            this.lastAPUMasterState = currentAPUMasterState;  
+            this.changePage("APU")
+
             //if external power is off when turning on apu, only show the apu page for 10 seconds, then the DOOR page
             var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "Bool")  
-            if (externalPower === 1) {  
+            if (externalPower === 0) {  
                 this.externalPowerWhenApuMasterOnTimer = 10
-                this.lastAPUMasterState = currentAPUMasterState;  
-                this.changePage("APU")
-            } else {  
-                this.lastAPUMasterState = currentAPUMasterState;  
-                this.changePage("APU");  
-            }  
+            }
 
         }
 
         if (this.externalPowerWhenApuMasterOnTimer >= 0) {  
-            this.externalPowerWhenApuMasterOnTimer -= _deltaTime
+            this.externalPowerWhenApuMasterOnTimer -= _deltaTime/1000
             if (this.externalPowerWhenApuMasterOnTimer <= 0) {  
                 this.changePage("DOOR")  
             }  

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -27,7 +27,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
     }
     Init() {
         super.Init();
-        this.changePage("DOOR");
+        this.changePage("DOOR"); // MODIFIED
 
         this.lastAPUMasterState = 0 // MODIFIED
         this.externalPowerWhenApuMasterOnTimer = -1 // MODIFIED
@@ -55,7 +55,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         }
 
         if (this.externalPowerWhenApuMasterOnTimer >= 0) {  
-            this.externalPowerWhenApuMasterOnTimer -= _deltaTime/1000
+            this.externalPowerWhenApuMasterOnTimer -= _deltaTime
             if (this.externalPowerWhenApuMasterOnTimer <= 0) {  
                 this.changePage("DOOR")  
             }  

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -51,6 +51,7 @@ var A320_Neo_LowerECAM_APU;
             if (this.lastAPUMasterState != currentAPUMasterState) {
                 this.lastAPUMasterState = currentAPUMasterState;
                 this.APUStartTimer = 20;
+                this.APUGenInfo.setAttribute("visibility", "visible");
             }
 
             if (this.APUStartTimer >= 0) {


### PR DESCRIPTION
Now the ECAM switch to the APU page automaticaly when apu master is on. If no external power is connected, only stay on the APU page for 10 seconds then switch to the DOOR page.
ECAM now start on the DOOR page, was previously the FUEL page.
Everything tested in sim, seems to work.