### PR TITLE
Added self tests to all displays

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html
@@ -16,6 +16,13 @@
                 <a320-neo-lower-ecam-door style="display:none"></a320-neo-lower-ecam-door> <!-- MODIFIED -->
                 <eicas-common-display id="CommonDisplay"></eicas-common-display>
             </div>
+            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none;" id="SelfTestDiv">
+                <svg id="SelfTest" viewBox="0 0 600 600" style="position:absolute; top:0%; left: 0%; width: 100%; height:100%;">
+                    <rect fill="black" x="0" y="0" width="100%" height="100%"></rect>
+                    <text id="self_test_text" fill="green" text-anchor="middle" x="50%" y="50%" font-size="30px">SELF TEST IN PROGRESS</text>
+                    <text id="self_test_text2" fill="green" text-anchor="middle" x="50%" y="56%" font-size="30px">(MAX 40 SECONDS)</text>
+                </svg>
+            </div>
         </div>
     </div>
 </script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -31,11 +31,34 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         this.lastAPUMasterState = 0 // MODIFIED
         this.externalPowerWhenApuMasterOnTimer = -1 // MODIFIED
+        this.selfTestDiv = this.querySelector("#SelfTestDiv");
+        this.selfTestTimer = -1;
+        this.selfTestTimerStarted = false;
     }
+    
     onUpdate(_deltaTime) {
         super.onUpdate(_deltaTime);
         this.updateAnnunciations();
 
+        var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
+        var engineOn = SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool");
+
+        // Check if engine is on so self test doesn't appear when not starting from cold and dark
+        if (engineOn) {
+            this.selfTestDiv.style.display = "none";
+            this.selfTestTimerStarted = true;
+        }
+        // Check if external power is on & timer not already started
+        if (externalPower && !this.selfTestTimerStarted) {
+            this.selfTestTimer = 14.25;
+            this.selfTestTimerStarted = true;
+        } // timer
+        if (this.selfTestTimer >= 0) {
+            this.selfTestTimer -= _deltaTime / 1000;
+            if (this.selfTestTimer <= 0) {
+                this.selfTestDiv.style.display = "none";
+            }
+        }
 
         // modification start here
         var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool");  

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html
@@ -89,6 +89,13 @@
                     </svg>
                 </div>
             </jet-mfd-nd-info>
+            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none;" id="SelfTestDiv">
+                <svg id="SelfTest" viewBox="0 0 600 600" style="position:absolute; top:0%; left: 0%; width: 100%; height:100%;">
+                    <rect fill="black" x="0" y="0" width="100%" height="100%"></rect>
+                    <text id="self_test_text" fill="green" text-anchor="middle" x="50%" y="50%" font-size="30px">SELF TEST IN PROGRESS</text>
+                    <text id="self_test_text2" fill="green" text-anchor="middle" x="50%" y="56%" font-size="30px">(MAX 40 SECONDS)</text>
+                </svg>
+            </div>
         </div>
     </div>
 </script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
@@ -87,11 +87,33 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
         this.showILS = SimVar.GetSimVarValue("L:BTN_LS_FILTER_ACTIVE", "bool");
         this.compass.showILS(this.showILS);
         this.info.showILS(this.showILS);
+        this.selfTestDiv = this.gps.getChildById("SelfTestDiv");
+        this.selfTestTimer = -1;
+        this.selfTestTimerStarted = false;
     }
     onUpdate(_deltaTime) {
         super.onUpdate(_deltaTime);
         this.updateMap(_deltaTime);
         this.updateNDInfo(_deltaTime);
+
+        var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
+        var engineOn = SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool");
+        if (engineOn) {
+            this.selfTestDiv.style.display = "none";
+            this.selfTestTimerStarted = true;
+        }
+        // Check if external power is on & timer not already started
+        if (externalPower && !this.selfTestTimerStarted) {
+            this.selfTestTimer = 13.75;
+            this.selfTestTimerStarted = true;
+        }
+        // Timer
+        if (this.selfTestTimer >= 0) {
+            this.selfTestTimer -= _deltaTime / 1000;
+            if (this.selfTestTimer <= 0) {
+                this.selfTestDiv.style.display = "none";
+            }
+        }
     }
     _updateNDFiltersStatuses() {
         SimVar.SetSimVarValue("L:BTN_CSTR_FILTER_ACTIVE", "number", this.map.instrument.showConstraints ? 1 : 0);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.html
@@ -16,6 +16,13 @@
                 <airbus-fma id="FMA"></airbus-fma>
                 <jet-pfd-ils-indicator id="ILS"></jet-pfd-ils-indicator>
             </div>
+            <div style="position: absolute; left: 0%; top: 0%; width: 100%; height: 100%; border: none;" id="SelfTestDiv">
+                <svg id="SelfTest" viewBox="0 0 600 600" style="position:absolute; top:0%; left: 0%; width: 100%; height:100%;">
+                    <rect fill="black" x="0" y="0" width="100%" height="100%"></rect>
+                    <text id="self_test_text" fill="green" text-anchor="middle" x="50%" y="50%" font-size="30px">SELF TEST IN PROGRESS</text>
+                    <text id="self_test_text2" fill="green" text-anchor="middle" x="50%" y="56%" font-size="30px">(MAX 40 SECONDS)</text>
+                </svg>
+            </div>
         </div>
     </div>
 </script>

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -1,0 +1,266 @@
+class A320_Neo_PFD extends BaseAirliners {
+    constructor() {
+        super();
+        this.initDuration = 7000;
+    }
+    get templateID() { return "A320_Neo_PFD"; }
+    get IsGlassCockpit() { return true; }
+    connectedCallback() {
+        super.connectedCallback();
+        this.pageGroups = [
+            new NavSystemPageGroup("Main", this, [
+                new A320_Neo_PFD_MainPage()
+            ]),
+        ];
+        this.maxUpdateBudget = 12;
+    }
+    disconnectedCallback() {
+        window.console.log("A320 Neo PFD - destroyed");
+        super.disconnectedCallback();
+    }
+    Update() {
+        super.Update();
+    }
+}
+class A320_Neo_PFD_MainElement extends NavSystemElement {
+    init(root) {
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+    }
+}
+class A320_Neo_PFD_MainPage extends NavSystemPage {
+    constructor() {
+        super("Main", "Mainframe", new A320_Neo_PFD_MainElement());
+        this.showILS = false;
+        this.attitude = new A320_Neo_PFD_Attitude();
+        this.vSpeed = new A320_Neo_PFD_VSpeed();
+        this.airspeed = new A320_Neo_PFD_Airspeed();
+        this.altimeter = new A320_Neo_PFD_Altimeter();
+        this.compass = new A320_Neo_PFD_Compass();
+        this.navStatus = new A320_Neo_PFD_NavStatus();
+        this.ils = new A320_Neo_PFD_ILS();
+        this.element = new NavSystemElementGroup([
+            this.attitude,
+            this.vSpeed,
+            this.airspeed,
+            this.altimeter,
+            this.compass,
+            this.navStatus,
+            this.ils
+        ]);
+    }
+    init() {
+        super.init();
+        this.showILS = SimVar.GetSimVarValue("L:BTN_LS_FILTER_ACTIVE", "bool");
+        this.ils.showILS(this.showILS);
+        this.compass.showILS(this.showILS);
+        this.selfTestDiv = this.gps.getChildById("SelfTestDiv");
+        this.selfTestTimer = -1;
+        this.selfTestTimerStarted = false;
+    }
+    onEvent(_event) {
+        switch (_event) {
+            case "BTN_LS":
+                this.showILS = !this.showILS;
+                SimVar.SetSimVarValue("L:BTN_LS_FILTER_ACTIVE", "number", this.showILS ? 1 : 0);
+                this.ils.showILS(this.showILS);
+                this.compass.showILS(this.showILS);
+                break;
+        }
+    }
+    onUpdate(_deltaTime) {
+        var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
+        var engineOn = SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool");
+        if (engineOn) {
+            this.selfTestDiv.style.display = "none";
+            this.selfTestTimerStarted = true;
+        }
+        // Check if external power is on & timer not already started
+        if (externalPower && !this.selfTestTimerStarted) {
+            this.selfTestTimer = 13;
+            this.selfTestTimerStarted = true;
+        }
+        // Timer
+        if (this.selfTestTimer >= 0) {
+            this.selfTestTimer -= _deltaTime / 1000;
+            if (this.selfTestTimer <= 0) {
+                this.selfTestDiv.style.display = "none";
+            }
+        }
+    }
+    
+}
+class A320_Neo_PFD_VSpeed extends NavSystemElement {
+    init(root) {
+        this.vsi = this.gps.getChildById("VSpeed");
+        this.vsi.aircraft = Aircraft.A320_NEO;
+        this.vsi.gps = this.gps;
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+        var vSpeed = Math.round(Simplane.getVerticalSpeed());
+        this.vsi.setAttribute("vspeed", vSpeed.toString());
+        if (Simplane.getAutoPilotVerticalSpeedHoldActive()) {
+            var selVSpeed = Math.round(Simplane.getAutoPilotVerticalSpeedHoldValue());
+            this.vsi.setAttribute("selected_vspeed", selVSpeed.toString());
+            this.vsi.setAttribute("selected_vspeed_active", "true");
+        }
+        else {
+            this.vsi.setAttribute("selected_vspeed_active", "false");
+        }
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+    }
+}
+class A320_Neo_PFD_Airspeed extends NavSystemElement {
+    constructor() {
+        super();
+    }
+    init(root) {
+        this.airspeed = this.gps.getChildById("Airspeed");
+        this.airspeed.aircraft = Aircraft.A320_NEO;
+        this.airspeed.gps = this.gps;
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+        this.airspeed.update(_deltaTime);
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+    }
+}
+class A320_Neo_PFD_Altimeter extends NavSystemElement {
+    constructor() {
+        super();
+    }
+    init(root) {
+        this.altimeter = this.gps.getChildById("Altimeter");
+        this.altimeter.aircraft = Aircraft.A320_NEO;
+        this.altimeter.gps = this.gps;
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+        this.altimeter.update(_deltaTime);
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+        switch (_event) {
+            case "BARO_INC":
+                SimVar.SetSimVarValue("K:KOHLSMAN_INC", "number", 1);
+                break;
+            case "BARO_DEC":
+                SimVar.SetSimVarValue("K:KOHLSMAN_DEC", "number", 1);
+                break;
+        }
+    }
+}
+class A320_Neo_PFD_Attitude extends NavSystemElement {
+    constructor() {
+        super(...arguments);
+        this.vDir = new Vec2();
+    }
+    init(root) {
+        this.hsi = this.gps.getChildById("Horizon");
+        this.hsi.aircraft = Aircraft.A320_NEO;
+        this.hsi.gps = this.gps;
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+        if (this.hsi) {
+            this.hsi.update(_deltaTime);
+            var xyz = Simplane.getOrientationAxis();
+            if (xyz) {
+                this.hsi.setAttribute("pitch", (xyz.pitch / Math.PI * 180).toString());
+                this.hsi.setAttribute("bank", (xyz.bank / Math.PI * 180).toString());
+            }
+            this.hsi.setAttribute("slip_skid", Simplane.getInclinometer().toString());
+            this.hsi.setAttribute("radio_altitude", Simplane.getAltitudeAboveGround().toString());
+            this.hsi.setAttribute("radio_decision_height", this.gps.radioNav.getRadioDecisionHeight().toString());
+        }
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+    }
+}
+class A320_Neo_PFD_Compass extends NavSystemElement {
+    init(root) {
+        this.hsi = this.gps.getChildById("Compass");
+        this.hsi.aircraft = Aircraft.A320_NEO;
+        this.hsi.gps = this.gps;
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+        this.hsi.update(_deltaTime);
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+    }
+    showILS(_val) {
+        if (this.hsi) {
+            this.hsi.showILS(_val);
+        }
+    }
+}
+class A320_Neo_PFD_NavStatus extends NavSystemElement {
+    init(root) {
+        this.fma = this.gps.getChildById("FMA");
+        this.fma.aircraft = Aircraft.A320_NEO;
+        this.fma.gps = this.gps;
+        this.isInitialized = true;
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+        if (this.fma != null) {
+            this.fma.update(_deltaTime);
+        }
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+    }
+}
+class A320_Neo_PFD_ILS extends NavSystemElement {
+    init(root) {
+        this.ils = this.gps.getChildById("ILS");
+        this.ils.aircraft = Aircraft.A320_NEO;
+        this.ils.gps = this.gps;
+    }
+    onEnter() {
+    }
+    onUpdate(_deltaTime) {
+        if (this.ils) {
+            this.ils.update(_deltaTime);
+        }
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+    }
+    showILS(_val) {
+        if (this.ils) {
+            this.ils.showLocalizer(_val);
+            this.ils.showGlideslope(_val);
+            this.ils.showNavInfo(_val);
+        }
+    }
+}
+registerInstrument("a320-neo-pfd-element", A320_Neo_PFD);
+//# sourceMappingURL=A320_Neo_PFD.js.map

--- a/A32NX/layout.json
+++ b/A32NX/layout.json
@@ -12,12 +12,12 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html",
-            "size": 4397,
+            "size": 5064,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js",
-            "size": 5163,
+            "size": 7345,
             "date": "132402817714110148"
         },
         {
@@ -32,7 +32,7 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js",
-            "size": 9487,
+            "size": 9559,
             "date": "132402817714110148"
         },
         {
@@ -82,17 +82,22 @@
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html",
-            "size": 9742,
+            "size": 10409,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js",
-            "size": 20993,
+            "size": 21906,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.html",
-            "size": 3784,
+            "size": 4451,
+            "date": "132402817714110148"
+        },
+        {
+            "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js",
+            "size": 7907,
             "date": "132402817714110148"
         },
         {


### PR DESCRIPTION
The timer for the self test relies on external power being on as when I was using the simvar for getting the battery state it was not working properly, and in the real aircraft none of the displays are actually supposed to be on if there is no external or apu power and only battery. However feel free to edit it if you'd prefer to have it triggered by the battery.