### PR TITLE
APU now shows XX + bug fixes

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -31,41 +31,18 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         this.lastAPUMasterState = 0 // MODIFIED
         this.externalPowerWhenApuMasterOnTimer = -1 // MODIFIED
-        this.doorPageActivated = false
-        this.selfTestDiv = this.querySelector("#SelfTestDiv");
-        this.selfTestTimer = -1;
-        this.selfTestTimerStarted = false;
 
+        this.doorPageActivated = false
     }
-    
     onUpdate(_deltaTime) {
         super.onUpdate(_deltaTime);
         this.updateAnnunciations();
 
-        var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
-        var engineOn = SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool");
-
-        // Check if engine is on so self test doesn't appear when not starting from cold and dark
-        if (engineOn) {
-            this.selfTestDiv.style.display = "none";
-            this.selfTestTimerStarted = true;
-        }
-        // Check if external power is on & timer not already started
-        if (externalPower && !this.selfTestTimerStarted) {
-            this.selfTestTimer = 14.25;
-            this.selfTestTimerStarted = true;
-        } // timer
-        if (this.selfTestTimer >= 0) {
-            this.selfTestTimer -= _deltaTime / 1000;
-            if (this.selfTestTimer <= 0) {
-                this.selfTestDiv.style.display = "none";
-            }
-        }
 
         // modification start here
         var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool");  
         // automaticaly switch to the APU page when apu master switch is on
-        if (this.lastAPUMasterState != currentAPUMasterState && this.lastAPUMasterState === 1) {  
+        if (this.lastAPUMasterState != currentAPUMasterState && currentAPUMasterState === 1) {  
             this.lastAPUMasterState = currentAPUMasterState;  
             this.changePage("APU")
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -55,10 +55,6 @@ var A320_Neo_LowerECAM_APU;
                 this.APUGenInfo.setAttribute("visibility", "visible");
             }
 
-            if (currentAPUMasterState === 0) {
-                // TODO: put xx instead of numbers in APU gauge if apu master is off
-            }
-
             if (this.APUStartTimer >= 0) {
                 this.APUStartTimer -= _deltaTime/1000;
                 if (this.APUStartTimer <= 0) {
@@ -212,6 +208,7 @@ var A320_Neo_LowerECAM_APU;
 
         getAPUN() {
             return SimVar.GetSimVarValue("APU PCT RPM", "percent");
+            
         }
 
         //Calculates the APU EGT Based on the RPM

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -184,11 +184,24 @@ var A320_Neo_LowerECAM_APU;
             if (_gaugeDiv != null) {
                 _gaugeDiv.appendChild(this.apuEGTGauge);
             }
-            this.apuInactiveTimer = 3
+            this.apuInactiveTimer = -1
+            this.lastAPUMasterState = 0
         }
 
         update(_deltaTime) {
             //Update gauges
+            var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool");
+            if ((currentAPUMasterState !== this.lastAPUMasterState)) {
+                if (currentAPUMasterState === 1) {
+                    this.apuInactiveTimer = 3
+                    this.lastAPUMasterState = currentAPUMasterState
+                } else {
+                    this.apuEGTGauge.active = false
+                    this.apuNGauge.active = false
+                    this.lastAPUMasterState = currentAPUMasterState
+                }
+                
+            }
             if (this.apuInactiveTimer >= 0) {
                 this.apuInactiveTimer -= _deltaTime/1000
                 if (this.apuInactiveTimer <= 0) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -191,15 +191,9 @@ var A320_Neo_LowerECAM_APU;
         update(_deltaTime) {
             //Update gauges
             var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool");
-            if ((currentAPUMasterState !== this.lastAPUMasterState)) {
-                if (currentAPUMasterState === 1) {
-                    this.apuInactiveTimer = 3
-                    this.lastAPUMasterState = currentAPUMasterState
-                } else {
-                    this.apuEGTGauge.active = false
-                    this.apuNGauge.active = false
-                    this.lastAPUMasterState = currentAPUMasterState
-                }
+            if ((currentAPUMasterState !== this.lastAPUMasterState) && currentAPUMasterState === 1) {
+                this.apuInactiveTimer = 3
+                this.lastAPUMasterState = currentAPUMasterState
                 
             }
             if (this.apuInactiveTimer >= 0) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -158,6 +158,7 @@ var A320_Neo_LowerECAM_APU;
             this.apuNGauge.addGraduation(0, true, "0");
             this.apuNGauge.addGraduation(50, true);
             this.apuNGauge.addGraduation(100, true, "10");
+            this.apuNGauge.active = false
             if (_gaugeDiv != null) {
                 _gaugeDiv.appendChild(this.apuNGauge);
             }
@@ -179,16 +180,22 @@ var A320_Neo_LowerECAM_APU;
             this.apuEGTGauge.addGraduation(300, true, "3");
             this.apuEGTGauge.addGraduation(700, true, "7");
             this.apuEGTGauge.addGraduation(1000, true, "10");
+            this.apuEGTGauge.active = false
             if (_gaugeDiv != null) {
                 _gaugeDiv.appendChild(this.apuEGTGauge);
             }
+            this.apuInactiveTimer = 3
         }
 
         update(_deltaTime) {
             //Update gauges
-            var currentAPUMasterState = SimVar.GetSimVarValue("FUELSYSTEM VALVE SWITCH:8", "Bool");
-            if (currentAPUMasterState === 0) {
-                this.apuNGauge.isActive = false
+            if (this.apuInactiveTimer >= 0) {
+                this.apuInactiveTimer -= _deltaTime/1000
+                if (this.apuInactiveTimer <= 0) {
+                    this.apuInactiveTimer = -1
+                    this.apuEGTGauge.active = true
+                    this.apuNGauge.active = true
+                }
             }
             if (this.apuNGauge != null && this.apuEGTGauge != null) {
                 this.apuNGauge.update(_deltaTime);


### PR DESCRIPTION
APU gauge now show XX when it's is off. it diseaper a few seconds after the master is pressed
fixed a bug where apu page would not automaticaly show up
this hasn't been tested in sim