### PR TITLE
Refactor `build.py` and add GitHub Actions CI

### DIFF
--- a/.github/workflows/check_git_diff.sh
+++ b/.github/workflows/check_git_diff.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+if [[ -z "$(git status --porcelain $STATUS_ARGS $PATHSPEC)" ]];
+then
+    echo "Working directory clean!"
+    exit 0
+else
+    echo "Working directory dirty. Did you run build.py?"
+    exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+      - name: Setup Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Ensure layout.json
+        run: |
+          cd ./A32NX
+          python3 build.py
+          cd ../
+          ./.github/workflows/check_git_diff.sh

--- a/A32NX/build.py
+++ b/A32NX/build.py
@@ -2,30 +2,46 @@ import os
 import json
 import sys
 
-if sys.version_info[0] < 3 or sys.version_info[1] < 6:
-    raise Exception("Must be using Python 3.6 or later")
 
-cwd = os.getcwd()
-json_content = {
-    "content": []
-}
+def check_prerequisites():
+    if sys.version_info[0] < 3 or sys.version_info[1] < 6:
+        raise Exception("Must be using Python 3.6 or later")
 
-for root, _, files in os.walk(cwd):
-    for filename in files:
-        filepath = os.path.join(root, filename)
 
-        if not filepath.endswith(".json") and not filepath.endswith(".py"):
-            rel_dir = os.path.relpath(root)
-            rel_file = str(os.path.join(rel_dir, filename))
-            if rel_file[0] == '.':
-                rel_file = rel_file[2:]
+def build_layout(project_dir):
+    layout_entries = []
+    for root, _, files in os.walk(project_dir):
+        for filename in files:
+            filepath = os.path.join(root, filename)
 
-            print(" -- Processing " + rel_file)
-            entry = {}
-            entry["path"] = rel_file.replace('\\', '/')
-            entry["size"] = os.path.getsize(filepath)
-            entry["date"] = "132402817714110148"
-            json_content["content"].append(entry)
+            if not filepath.endswith(".json") and not filepath.endswith(".py"):
+                rel_dir = os.path.relpath(root)
+                rel_file = str(os.path.join(rel_dir, filename))
+                if rel_file[0] == '.':
+                    rel_file = rel_file[2:]
 
-with open("layout.json", "w") as outfile:
-    json.dump(json_content, outfile, indent=4)
+                print(" -- Processing " + rel_file)
+                entry = {}
+                entry["path"] = rel_file.replace('\\', '/')
+                entry["size"] = os.path.getsize(filepath)
+                entry["date"] = "132402817714110148"
+                layout_entries.append(entry)
+
+    layout_entries.sort(key=lambda e: e["path"])
+
+    return layout_entries
+
+
+if __name__ == "__main__":
+    check_prerequisites()
+
+    cwd = os.getcwd()
+
+    layout_content = build_layout(cwd)
+
+    layout_json = {
+        "content": layout_content
+    }
+
+    with open("layout.json", "w") as outfile:
+        json.dump(layout_json, outfile, indent=4)

--- a/A32NX/layout.json
+++ b/A32NX/layout.json
@@ -1,93 +1,93 @@
 {
     "content": [
         {
+            "path": "ModelBehaviorDefs/Airliner/Airbus.xml",
+            "size": 36725,
+            "date": "132402817714110148"
+        },
+        {
+            "path": "ModelBehaviorDefs/Asobo/Airliner/Airbus.xml",
+            "size": 37469,
+            "date": "132402817714110148"
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/engines.cfg",
+            "size": 10383,
+            "date": "132402817714110148"
+        },
+        {
+            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/systems.cfg",
+            "size": 17699,
+            "date": "132402817714110148"
+        },
+        {
             "path": "html_ui/Fonts/B612Mono-Regular.ttf",
             "size": 140292,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.html",
-            "size": 4397,
+            "size": 4338,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js",
-            "size": 4713,
+            "size": 4638,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.css",
-            "size": 1878,
+            "size": 1791,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.html",
-            "size": 2877,
+            "size": 2817,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js",
-            "size": 7384,
+            "size": 7195,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.css",
-            "size": 766,
+            "size": 734,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.html",
-            "size": 483,
+            "size": 472,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_BLEED.js",
-            "size": 966,
+            "size": 939,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.css",
-            "size": 2513,
+            "size": 2424,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.html",
-            "size": 4131,
+            "size": 4068,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_DOOR.js",
-            "size": 5140,
+            "size": 5038,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html",
-            "size": 9742,
+            "size": 9607,
             "date": "132402817714110148"
         },
         {
             "path": "html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js",
-            "size": 20993,
-            "date": "132402817714110148"
-        },
-        {
-            "path": "ModelBehaviorDefs/Airliner/Airbus.xml",
-            "size": 37721,
-            "date": "132402817714110148"
-        },
-        {
-            "path": "ModelBehaviorDefs/Asobo/Airliner/Airbus.xml",
-            "size": 38465,
-            "date": "132402817714110148"
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/engines.cfg",
-            "size": 10486,
-            "date": "132402817714110148"
-        },
-        {
-            "path": "SimObjects/AirPlanes/Asobo_A320_NEO/systems.cfg",
-            "size": 17926,
+            "size": 20504,
             "date": "132402817714110148"
         }
     ]

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Join our Discord server to find out about the latest updates and discuss ongoing
 
 [![Discord](https://img.shields.io/discord/738864299392630914.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/UjzuHMU)
 
+### Committing changes
 
-**ALWAYS REMEMBER TO RUN BUILD.PY BEFORE COMMITTING NEW FILES**
+After making any changes to files inside the `A32NX` directory, ensure you run the `build.py` script to regenerate the `layout.json` as necessary. There's also a CI check to ensure this has been done.
 
 ## Changelog
 


### PR DESCRIPTION
Hello!

I'm very happy to see some open source work being done in FS2020. I'm still working my way through the SDK docs and getting familiar with this project, so in the meantime I thought it might be nice to add a CI system.

This PR adds a few things:

- A GitHub Actions workflow with a single `CI` job. This will execute on every pull request and any pushes/merges into `master`. Right now, this verifies that `build.py` has been run before a PR can be merged.
- Refactors the `build.py` to move some of the logic into separate functions.
- Modifies `build.py` to sort `layout.json` alphabetically so we get a consistent result regardless of any Python version or OS inconsistencies.

Let me know your thoughts! And thanks for open sourcing this project :D