### PR TITLE
Fixed a bug that made the displays go off when starting on the runway at certain airports

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -35,6 +35,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         this.onFuel = () => { CDUFuelPredPage.ShowPage(this); };
         CDUIdentPage.ShowPage(this);
         this.electricity = this.querySelector("#Electricity")
+        this.displaysAbleToTurnOff = true;
     }
     onPowerOn() {
         super.onPowerOn();
@@ -56,15 +57,18 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var engineOn = SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool");
         var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");
+        var onRunway = SimVar.GetSimVarValue("ON ANY RUNWAY", "bool");
+        var isOnGround = SimVar.GetSimVarValue("SIM ON GROUND", "bool")
 
-        this.updateScreenState(externalPower, engineOn, apuOn);
+        this.updateScreenState(externalPower, engineOn, apuOn, onRunway, isOnGround);
     }
 
-    updateScreenState(externalPowerOn, engineOn, apuOn) {
-        if (!externalPowerOn && !engineOn && !apuOn) {
+    updateScreenState(externalPowerOn, engineOn, apuOn, onRunway, isOnGround) {
+        if (!externalPowerOn && !apuOn && !engineOn && !onRunway && isOnGround && this.displaysAbleToTurnOff) {
             this.electricity.style.display = "none";
         } else {
             this.electricity.style.display = "block";
+            this.displaysAbleToTurnOff = false;
         }
     }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -36,6 +36,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         this.selfTestTimerStarted = false;
         this.doorPageActivated = false
         this.electricity = this.querySelector("#Electricity")
+        this.displaysAbleToTurnOff = true;
         this.changePage("DOOR"); // MODIFIED
         
     }
@@ -46,8 +47,10 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var engineOn = SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool");
         var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");
+        var onRunway = SimVar.GetSimVarValue("ON ANY RUNWAY", "bool");
+        var isOnGround = SimVar.GetSimVarValue("SIM ON GROUND", "bool")
 
-        this.updateScreenState(externalPower, engineOn, apuOn);
+        this.updateScreenState(externalPower, engineOn, apuOn, onRunway, isOnGround);
 
         // Check if engine is on so self test doesn't appear when not starting from cold and dark
         if (engineOn) {
@@ -103,11 +106,12 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
         // modification ends here
     }
 
-    updateScreenState(externalPowerOn, engineOn, apuOn) {
-        if (!externalPowerOn && !engineOn && !apuOn) {
+    updateScreenState(externalPowerOn, engineOn, apuOn, onRunway, isOnGround) {
+        if (!externalPowerOn && !apuOn && !engineOn && !onRunway && isOnGround && this.displaysAbleToTurnOff) {
             this.electricity.style.display = "none";
         } else {
             this.electricity.style.display = "block";
+            this.displaysAbleToTurnOff = false;
         }
     }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.js
@@ -93,6 +93,7 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
         this.selfTestTimer = -1;
         this.selfTestTimerStarted = false;
         this.electricity = this.gps.getChildById("Electricity")
+        this.displaysAbleToTurnOff = true;
     }
     onUpdate(_deltaTime) {
         super.onUpdate(_deltaTime);
@@ -117,9 +118,11 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
 
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var engineOn = SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool");
-        var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");   
+        var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");
+        var onRunway = SimVar.GetSimVarValue("ON ANY RUNWAY", "bool");
+        var isOnGround = SimVar.GetSimVarValue("SIM ON GROUND", "bool")
         
-        this.updateScreenState(externalPower, engineOn, apuOn);
+        this.updateScreenState(externalPower, engineOn, apuOn, onRunway, isOnGround);
 
         if (engineOn) {
             this.selfTestDiv.style.display = "none";
@@ -140,11 +143,12 @@ class A320_Neo_MFD_MainPage extends NavSystemPage {
         
     }
 
-    updateScreenState(externalPowerOn, engineOn, apuOn) {
-        if (!externalPowerOn && !engineOn && !apuOn) {
+    updateScreenState(externalPowerOn, engineOn, apuOn, onRunway, isOnGround) {
+        if (!externalPowerOn && !apuOn && !engineOn && !onRunway && isOnGround && this.displaysAbleToTurnOff) {
             this.electricity.style.display = "none";
         } else {
             this.electricity.style.display = "block";
+            this.displaysAbleToTurnOff = false;
         }
     }
 

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -83,6 +83,7 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
         this.selfTestDiv = this.gps.getChildById("SelfTestDiv");
         this.selfTestTimerStarted = false;
         this.electricity = this.gps.getChildById("Electricity")
+        this.displaysAbleToTurnOff = true;
     }
     onUpdate(_deltaTime) {
         super.onUpdate();
@@ -125,9 +126,11 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
 
         var externalPower = SimVar.GetSimVarValue("EXTERNAL POWER ON", "bool");
         var engineOn = SimVar.GetSimVarValue("GENERAL ENG STARTER:1", "bool");
-        var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");  
+        var apuOn = SimVar.GetSimVarValue("APU SWITCH", "bool");
+        var onRunway = SimVar.GetSimVarValue("ON ANY RUNWAY", "bool");
+        var isOnGround = SimVar.GetSimVarValue("SIM ON GROUND", "bool")
 
-        this.updateScreenState(externalPower, engineOn, apuOn);
+        this.updateScreenState(externalPower, engineOn, apuOn, onRunway, isOnGround);
 
         if (engineOn) {
             this.selfTestDiv.style.display = "none";
@@ -157,11 +160,12 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
         }
     }
 
-    updateScreenState(externalPowerOn, engineOn, apuOn) {
-        if (!externalPowerOn && !engineOn && !apuOn) {
+    updateScreenState(externalPowerOn, engineOn, apuOn, onRunway, isOnGround) {
+        if (!externalPowerOn && !apuOn && !engineOn && !onRunway && isOnGround && this.displaysAbleToTurnOff) {
             this.electricity.style.display = "none";
         } else {
             this.electricity.style.display = "block";
+            this.displaysAbleToTurnOff = false;
         }
     }
     


### PR DESCRIPTION
This in turn disabled the functionality I added for making the screens also go off when shutting down the aircraft (still works when powering on), but it's better than having the displays off when not starting cold and dark until I work on a solution.