### PR TITLE
APU gen arrow only show when no EXTERN POWER connected

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -100,7 +100,7 @@ var A320_Neo_LowerECAM_APU;
             //AVAIL indication & bleed pressure
             if (APUPctRPM > 95) {
                 this.APUAvail.setAttribute("visibility", "visible");
-                if (SimVar.GetSimVarValue("APU GENERATOR ACTIVE", "Bool") == 1) this.APUGenAvailArrow.setAttribute("visibility", "visible");
+                if (SimVar.GetSimVarValue("APU GENERATOR ACTIVE", "Bool") == 1 && SimVar.GetSimVarValue("EXTERNAL POWER ON", "Bool") === 0) this.APUGenAvailArrow.setAttribute("visibility", "visible");
                 else this.APUGenAvailArrow.setAttribute("visibility", "hidden");
                 this.APUBleedPressure.textContent = "35";
                 this.APUBleedPressure.setAttribute("class", "APUGenParamValue");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -182,7 +182,7 @@ var A320_Neo_LowerECAM_APU;
             }
             this.apuInactiveTimer = -1
             this.lastAPUMasterState = 0
-            this.apuShutingDown = false
+            this.apuShuttingDown = false
         }
 
         update(_deltaTime) {
@@ -191,12 +191,12 @@ var A320_Neo_LowerECAM_APU;
             if ((currentAPUMasterState !== this.lastAPUMasterState) && currentAPUMasterState === 1) {
                 this.apuInactiveTimer = 3
                 this.lastAPUMasterState = currentAPUMasterState
-                this.apuShutingDown = false
+                this.apuShuttingDown = false
             }
             if ((currentAPUMasterState !== this.lastAPUMasterState) && currentAPUMasterState === 0) {
-                this.apuShutingDown = true
+                this.apuShutitngDown = true
             }
-            if (this.apuShutingDown && SimVar.GetSimVarValue("APU PCT RPM", "percent") === 0) {
+            if (this.apuShuttingDown && SimVar.GetSimVarValue("APU PCT RPM", "percent") === 0) {
                 this.apuEGTGauge.active = false
                 this.apuNGauge.active = false
             }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -194,7 +194,7 @@ var A320_Neo_LowerECAM_APU;
                 this.apuShuttingDown = false
             }
             if ((currentAPUMasterState !== this.lastAPUMasterState) && currentAPUMasterState === 0) {
-                this.apuShutitngDown = true
+                this.apuShuttingDown = true
             }
             if (this.apuShuttingDown && SimVar.GetSimVarValue("APU PCT RPM", "percent") === 0) {
                 this.apuEGTGauge.active = false

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -182,6 +182,7 @@ var A320_Neo_LowerECAM_APU;
             }
             this.apuInactiveTimer = -1
             this.lastAPUMasterState = 0
+            this.apuShutingDown = false
         }
 
         update(_deltaTime) {
@@ -190,7 +191,14 @@ var A320_Neo_LowerECAM_APU;
             if ((currentAPUMasterState !== this.lastAPUMasterState) && currentAPUMasterState === 1) {
                 this.apuInactiveTimer = 3
                 this.lastAPUMasterState = currentAPUMasterState
-                
+                this.apuShutingDown = false
+            }
+            if ((currentAPUMasterState !== this.lastAPUMasterState) && currentAPUMasterState === 0) {
+                this.apuShutingDown = true
+            }
+            if (this.apuShutingDown && SimVar.GetSimVarValue("APU PCT RPM", "percent") === 0) {
+                this.apuEGTGauge.active = false
+                this.apuNGauge.active = false
             }
             if (this.apuInactiveTimer >= 0) {
                 this.apuInactiveTimer -= _deltaTime/1000


### PR DESCRIPTION
Fixes #20 
Couldn't get it to work with engine GEN because there is not enough simvar for it, will wait until someone does a more realistic ELEC system