### PR TITLE
Replaced wind arrow on ND

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.css
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.css
@@ -142,6 +142,8 @@
           left: 0%;
           width: 40%;
           position: absolute; }
+        a320-neo-mfd-element #Mainframe #TopBox #Speed svg {
+          overflow: visible; }
         a320-neo-mfd-element #Mainframe #TopBox #Title {
           top: 15%;
           height: 100%;

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/MFD/A320_Neo_MFD.html
@@ -32,7 +32,10 @@
                             <text id="Wind_Direction" class="Value" x="0%" y="45%" alignment-baseline="baseline">--</text>
                             <text id="Wind_Separator" class="Large" x="14%" y="45%" alignment-baseline="baseline">/</text>
                             <text id="Wind_Strength" class="Value" x="22%" y="45%" alignment-baseline="baseline">--</text>
-                            <polygon id="Wind_Arrow" points="-5 20, 5 20, 5 -20, 15 -20, 0 -40, -15 -20, -5 -20" transform="translate(40 130) rotate(0)" fill="lime" display="none" />
+                            <g id="Wind_Arrow" transform="translate(40 130) rotate(0)" fill="none" stroke="lime" stroke-width="5" stroke-linejoin="round" stroke-linecap="round" display="none">
+                                <polyline points="0,16 0,-35" />
+                                <polyline points="15,-20, 0,-40 -15,-20" />
+                            </g>
                         </svg>
                     </div>
 


### PR DESCRIPTION
Replaced wind arrow on top left of ND to more closely resemble irl.

IRL:
![image](https://user-images.githubusercontent.com/3533988/91517903-959be280-e8b4-11ea-9489-c2eb7414e6a3.png)


Asobo:
![image](https://user-images.githubusercontent.com/3533988/91517890-89b02080-e8b4-11ea-900c-d2ee82eb8e03.png)


My change:
![image](https://user-images.githubusercontent.com/3533988/91517884-8321a900-e8b4-11ea-934f-f2393b151e00.png)
