### PR TITLE
Made overspeed trigger master warning and ecam message, removed voice…

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.xml
@@ -273,6 +273,14 @@
 			</Inequal>
 		  </Condition>
 		</Annunciation>
+
+		<Annunciation>
+		  <Type>Warning</Type>
+		  <Text>OVERSPEED</Text>
+		  <Condition>
+			<Simvar name="OVERSPEED WARNING" unit="bool"/>
+		  </Condition>
+		</Annunciation>
 	</Annunciations>
   
 	<!-- Voices Alerts -->
@@ -733,14 +741,6 @@
 			<SoundEvent>aural_stall</SoundEvent>
 			<Condition>
 				<Simvar name="STALL WARNING" unit="Bool"/>
-			</Condition>
-		</Alert>
-				
-		<Alert>
-			<Type>SoundOnly</Type>
-			<SoundEvent>aural_overspeed</SoundEvent>
-			<Condition>
-				<Simvar name="OVERSPEED WARNING" unit="bool"/>
 			</Condition>
 		</Alert>
 	</VoicesAlerts>

--- a/A32NX/layout.json
+++ b/A32NX/layout.json
@@ -52,7 +52,7 @@
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.xml",
-            "size": 19226,
+            "size": 19219,
             "date": "132402817714110148"
         },
         {


### PR DESCRIPTION
Voice repeating "Overspeed" has been removed.
Overspeeding now creates a master warning, and displays "OVERSPEED" on the ECAM.

Following video demonstrates changes: https://youtu.be/1N4-s1_poJc