### PR TITLE
[Fix] CI permission denied error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,5 @@ jobs:
           cd ./A32NX
           python3 build.py
           cd ../
+          chmod +x ./.github/workflows/check_git_diff.sh
           ./.github/workflows/check_git_diff.sh


### PR DESCRIPTION
This PR fixes an issue introduced by https://github.com/wpine215/msfs-a320neo/pull/108 where the GitHub Actions `ci` workflow fails with a `Permission denied` error.