### PR TITLE
Advisory ECAM Message Fix

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -180,7 +180,7 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
                 }
                 for (let i = this.annunciations.displayAdvisory.length - 1; i >= 0; i--) {
                     if (!this.annunciations.displayAdvisory[i].Acknowledged)
-                        infoPanelManager.addMessage(Airliners.EICAS_INFO_PANEL_ID.PRIMARY, this.annunciations.displayAdvisory[i].Text, (onGround) ? Airliners.EICAS_INFO_PANEL_MESSAGE_STYLE.INDICATION : Airliners.EICAS_INFO_PANEL_MESSAGE_STYLE.CAUTION);
+                        infoPanelManager.addMessage(Airliners.EICAS_INFO_PANEL_ID.PRIMARY, this.annunciations.displayAdvisory[i].Text, Airliners.EICAS_INFO_PANEL_MESSAGE_STYLE.INDICATION);
                 }
             }
         }


### PR DESCRIPTION
Fixed Advisory messages after take-off. 

Previously showing green message on the ground and then moved to a caution once in the air.

#193 
#214 

