### PR TITLE
Update A320_Neo_LowerECAM_APU.js --APU Startup Time 

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/ECAM/A320_Neo_LowerECAM_APU.js
@@ -51,7 +51,7 @@ var A320_Neo_LowerECAM_APU;
 
             if (this.lastAPUMasterState != currentAPUMasterState) {
                 this.lastAPUMasterState = currentAPUMasterState;
-                this.APUStartTimer = 20;
+                this.APUStartTimer = 3;// JZ initialisation time reduced from 20 to 3 according @dalmont this.APUStartTimer = 20;
                 this.APUGenInfo.setAttribute("visibility", "visible");
             }
 


### PR DESCRIPTION
temporary fix modified the APU startup time from 20 sec to 3 according to @Dalmont (Flap opens much quicker on the NEo)