### PR TITLE
Activate both AP1 and AP2 at the same time

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -18,7 +18,7 @@
 	<Include Path="Asobo\Airliner\GlassCockpit.xml"/>
 	<Include Path="Asobo\Airliner\Airbus.xml"/>
 
-<!-- RETROECLAIRAGE #############################################################################################################-->	
+<!-- RETROECLAIRAGE #############################################################################################################-->
 	<Component ID="MCDU">
 		<UseTemplate Name="ASOBO_FMC_A320">
 			<ID>1</ID>
@@ -319,42 +319,42 @@
 			<NODE_ID_SCREEN>SCREEN_MCDUR</NODE_ID_SCREEN>
 		</UseTemplate>
 	</Component>
-	
-	<Component ID="LIGHTING">		
+
+	<Component ID="LIGHTING">
 		<UseTemplate Name="ASOBO_LIGHTING_Knob_Pedestal_Template">
 			<NODE_ID>LIGHTING_Knob_Pedestal</NODE_ID>
 			<ANIM_NAME>LIGHTING_Knob_Pedestal</ANIM_NAME>
 			<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_PEDESTAL_DECREASE</ANIMTIP_0>
 			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_PEDESTAL_INCREASE</ANIMTIP_1>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Pedestal_Emissive_Template">
 			<NODE_ID>LIGHT_OVHD_TOPEDESTAL</NODE_ID>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Knob_Panel_Template">
 			<POTENTIOMETER>15</POTENTIOMETER>
 			<SIMVAR_INDEX>1</SIMVAR_INDEX>
 			<NODE_ID>LIGHTING_Knob_Panel</NODE_ID>
 			<ANIM_NAME>LIGHTING_Knob_Panel</ANIM_NAME>
 		</UseTemplate>
-		
+
 		<!-- All Pedestal & Main Panel Backlighting should be on potentiometer 15 -->
 		<UseTemplate Name="ASOBO_LIGHTING_Panel_Emissive_Template">
 			<NODE_ID>LIGHTS_PEDESTAL</NODE_ID>
 			<POTENTIOMETER>15</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Panel_Emissive_Template">
 			<NODE_ID>LEVER_ELEVATORTRIM_DECAL</NODE_ID>
 			<POTENTIOMETER>15</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Panel_Emissive_Template">
 			<NODE_ID>LIGHTS_MAINPANEL</NODE_ID>
 			<POTENTIOMETER>15</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<!-- Front Glareshields -->
 		<UseTemplate Name="ASOBO_LIGHTING_Knob_Glareshield_Template">
 			<ID>1</ID>
@@ -363,13 +363,13 @@
 			<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_MAIN_PANEL_FLOOD_DECREASE</ANIMTIP_0>
 			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHTING_MAIN_PANEL_FLOOD_INCREASE</ANIMTIP_1>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Glareshield_Emissive_Template">
 			<NODE_ID>LIGHTS_Glareshield_Front_1</NODE_ID>
 			<SIMVAR_INDEX>1</SIMVAR_INDEX>
 			<POTENTIOMETER>11</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Knob_Glareshield_Template">
 			<NODE_ID>LIGHTING_Knob_Glareshield_4</NODE_ID>
 			<ANIM_NAME>LIGHTING_Knob_Glareshield_4</ANIM_NAME>
@@ -377,13 +377,13 @@
 			<SIMVAR_INDEX>2</SIMVAR_INDEX>
 			<POTENTIOMETER>12</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Glareshield_Emissive_Template">
 			<NODE_ID>LIGHTS_Glareshield_Front_2</NODE_ID>
 			<SIMVAR_INDEX>2</SIMVAR_INDEX>
 			<POTENTIOMETER>12</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<!-- Triangle Glareshields -->
 		<UseTemplate Name="ASOBO_LIGHTING_Knob_Glareshield_Template">
 			<NODE_ID>LIGHTING_Knob_Glareshield</NODE_ID>
@@ -392,31 +392,31 @@
 			<SIMVAR_INDEX>3</SIMVAR_INDEX>
 			<POTENTIOMETER>13</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Glareshield_Emissive_Template">
 			<NODE_ID>LIGHTS_Glareshield_1</NODE_ID>
 			<SIMVAR_INDEX>3</SIMVAR_INDEX>
 			<POTENTIOMETER>13</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Glareshield_Emissive_Template">
 			<NODE_ID>LIGHTS_Glareshield_2</NODE_ID>
 			<SIMVAR_INDEX>3</SIMVAR_INDEX>
 			<POTENTIOMETER>13</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Glareshield_Emissive_Template">
 			<NODE_ID>LIGHTS_Glareshield_3</NODE_ID>
 			<SIMVAR_INDEX>3</SIMVAR_INDEX>
 			<POTENTIOMETER>13</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Glareshield_Emissive_Template">
 			<NODE_ID>LIGHTS_Glareshield_4</NODE_ID>
 			<SIMVAR_INDEX>3</SIMVAR_INDEX>
 			<POTENTIOMETER>13</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<!-- Panel Lights -->
 		<UseTemplate Name="ASOBO_LIGHTING_Knob_Panel_Template">
 			<NODE_ID>LIGHTING_Knob_Glareshield_2</NODE_ID>
@@ -425,13 +425,13 @@
 			<SIMVAR_INDEX>2</SIMVAR_INDEX>
 			<POTENTIOMETER>14</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Panel_Emissive_Template">
 			<NODE_ID>LIGHTS_AUTOPILOT</NODE_ID>
 			<SIMVAR_INDEX>2</SIMVAR_INDEX>
 			<POTENTIOMETER>14</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
 			<NODE_ID>LIGHTING_Knob_Glareshield_3</NODE_ID>
 			<ANIM_NAME>LIGHTING_Knob_Glareshield_3</ANIM_NAME>
@@ -439,16 +439,16 @@
 			<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.FD_DISPLAY_BRIGHTNESS_DECREASE</ANIMTIP_0>
 			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.FD_DISPLAY_BRIGHTNESS_INCREASE</ANIMTIP_1>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_LIGHTING_Potentiometer_Emissive_Template">
 			<NODE_ID>SCREEN_AUTOPILOT</NODE_ID>
 			<POTENTIOMETER>17</POTENTIOMETER>
 		</UseTemplate>
 	</Component>
-	
-	
-	<!-- G1000 ###################################### -->	
-	
+
+
+	<!-- G1000 ###################################### -->
+
 	<Component ID="Screen_emissive" Node="DYN_SCREEN">
 		<Material>
 			<EmissiveFactor>
@@ -457,7 +457,7 @@
 				</Parameter>
 			</EmissiveFactor>
 		</Material>
-	</Component>		
+	</Component>
 
 	<Component ID="Pedestal_Fwd">
 		<!-- TODO - Test this with new anim -->
@@ -486,28 +486,28 @@
 		<Component ID="Throttle_1_Visibility" Node="LEVER_THROTTLE_1">
 			<UseTemplate Name="ASOBO_GT_Visibility_Code">
 				<VISIBILITY_CODE>(L:XMLVAR_LeverThrottleHidden1) !</VISIBILITY_CODE>
-			</UseTemplate> 
+			</UseTemplate>
 		</Component>
 		<Component ID="Throttle_2_Visibility" Node="LEVER_THROTTLE_2">
 			<UseTemplate Name="ASOBO_GT_Visibility_Code">
 				<VISIBILITY_CODE>(L:XMLVAR_LeverThrottleHidden2) !</VISIBILITY_CODE>
-			</UseTemplate> 
+			</UseTemplate>
 		</Component>
-	
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_AutoThrottle_Disengage_Template">
 			<NODE_ID>PUSH_THROTTLE_1</NODE_ID>
 			<ANIM_NAME>PUSH_THROTTLE_1</ANIM_NAME>
 			<NO_INDICATOR>True</NO_INDICATOR>
 			<NO_TEXT_EMISSIVE>True</NO_TEXT_EMISSIVE>
-		</UseTemplate>	
-	
+		</UseTemplate>
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_AutoThrottle_Disengage_Template">
 			<NODE_ID>PUSH_THROTTLE_2</NODE_ID>
 			<ANIM_NAME>PUSH_THROTTLE_2</ANIM_NAME>
 			<NO_INDICATOR>True</NO_INDICATOR>
 			<NO_TEXT_EMISSIVE>True</NO_TEXT_EMISSIVE>
-		</UseTemplate>	
-	
+		</UseTemplate>
+
 		<UseTemplate Name="ASOBO_HANDLING_Wheel_ElevatorTrim_Template">
 			<ANIM_NAME>lever_trimtab_elevator_key_pct</ANIM_NAME>
 			<NODE_ID>LEVER_ELEVATORTRIM_1</NODE_ID>
@@ -518,7 +518,7 @@
 			<DRAG_MIN_VALUE>-4854</DRAG_MIN_VALUE> <!-- Limit to -4.5 deg -->
 
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_HANDLING_Indicator_ElevatorTrim_Template">
 			<ANIM_NAME>LEVER_ELEVATORTRIM_DECAL</ANIM_NAME>
 			<MIN_DISPLAYABLE>-4</MIN_DISPLAYABLE>
@@ -531,16 +531,16 @@
 			<ANIM_VALUE_2>100</ANIM_VALUE_2>
 			<MAX_POINT_INDEX>2</MAX_POINT_INDEX>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 			<NODE_ID>DECAL_THROTTLE_01</NODE_ID>
 			<POTENTIOMETER>15</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<CameraTitle>PedestalFwd</CameraTitle>
 	</Component>
-	
-	<Component ID="Pedestal_Aft">	
+
+	<Component ID="Pedestal_Aft">
 		<Component ID="Engines">
 			<UseTemplate Name="ASOBO_ENGINE_Switch_Master_Template">
 				<AIRBUS_TYPE/>
@@ -551,7 +551,7 @@
 				<POTENTIOMETER>15</POTENTIOMETER>
 
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_ENGINE_Switch_Master_Template">
 				<AIRBUS_TYPE/>
 				<ANIM_NAME>SWITCH_ENGINES_ENG2</ANIM_NAME>
@@ -560,10 +560,10 @@
 				<VALVE_ID>7</VALVE_ID>
 				<POTENTIOMETER>15</POTENTIOMETER>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_AIRBUS_Update_PTU_Template">
 			</UseTemplate>
-			
+
 			<!-- Mixture Lever does not exist in A320 but can be set to 0 by Auto Shutdown. Ensure it is always >0.9 -->
 			<Update Frequency="1">
 				(A:GENERAL ENG MIXTURE LEVER POSITION:1, Percent over 100) 0.9 &lt; if{ (&gt;K:MIXTURE1_RICH) }
@@ -591,7 +591,7 @@
 				<RESET_PUSH_ANIM_NAME>PUSH_RUDDERTRIM_RESET</RESET_PUSH_ANIM_NAME>
 				<RESET_PUSH_NODE_ID>PUSH_RUDDERTRIM_RESET</RESET_PUSH_NODE_ID>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_HANDLING_Lever_With_Button_Flaps_Template">
 				<NODE_ID>LEVER_FLAPS</NODE_ID>
 				<ANIM_NAME_LEVER>flaps_lever</ANIM_NAME_LEVER>
@@ -613,18 +613,18 @@
 				<ANIMTIP_4>TT:COCKPIT.TOOLTIPS.FLAPS_LEVER_FULL</ANIMTIP_4>
 
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_LANDING_GEAR_Switch_ParkingBrake_Template">
 				<ANIM_NAME>lever_parking_brake</ANIM_NAME>
 				<NODE_ID>LEVER_PARKINGBRAKE</NODE_ID>
 			</UseTemplate>
-			
+
 			<Component ID="Parking_Brake_Text" Node="LEVER_PARKINGBRAKE_SEQ1">
 				<UseTemplate Name="ASOBO_GT_Emissive_Potentiometer">
 					<POTENTIOMETER>15</POTENTIOMETER>
 				</UseTemplate>
 			</Component>
-			
+
 			<UseTemplate Name="ASOBO_HANDLING_Lever_Spoilers_Template">
 				<ANIM_NAME>lever_speed_brake</ANIM_NAME>
 				<NODE_ID>LEVER_SPEEDBRAKE</NODE_ID>
@@ -632,11 +632,11 @@
 				<TOOLTIPID>TT:COCKPIT.TOOLTIPS.SPEEDBRAKE_LEVER</TOOLTIPID>
 			</UseTemplate>
 		</Component>
-		
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 			<NODE_ID>PUSH_DOORPANEL_OPEN</NODE_ID>
 		</UseTemplate>
-		
+
 		<Component ID="WeatherRadar">
 			<UseTemplate Name="ASOBO_AIRBUS_WeatherRadar_Template">
 				<NODE_ID_MODE_KNOB>KNOB_RADAR_MODE</NODE_ID_MODE_KNOB>
@@ -644,10 +644,10 @@
 				<NODE_ID_ONOFF_SWITCH>SWITCH_RADAR_SYS</NODE_ID_ONOFF_SWITCH>
 				<ANIM_NAME_ONOFF_SWITCH>SWITCH_RADAR_SYS</ANIM_NAME_ONOFF_SWITCH>
 			</UseTemplate>
-		</Component>		
+		</Component>
 		<CameraTitle>PedestalAft</CameraTitle>
 	</Component>
-	
+
 	<Component ID="Front_Sides">
 		<UseTemplate Name="ASOBO_HANDLING_RudderPedals_Template">
 			<RUDDERPEDALS_TYPE>MIXED</RUDDERPEDALS_TYPE>
@@ -670,7 +670,7 @@
 			<ANIM_NAME_YOKE_X>yoke_lever_stick2_l_r</ANIM_NAME_YOKE_X>
 			<ANIM_NAME_YOKE_Y>yoke_lever_stick_fore2_aft</ANIM_NAME_YOKE_Y>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_HANDLING_Push_AP_Trim_Disc_Template">
 			<NODE_ID>PUSH_YOKE_LEFT</NODE_ID>
 			<ANIM_NAME>PUSH_YOKE_LEFT</ANIM_NAME>
@@ -679,7 +679,7 @@
 			<NODE_ID>PUSH_YOKE_RIGHT</NODE_ID>
 			<ANIM_NAME>PUSH_YOKE_RIGHT</ANIM_NAME>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_HANDLING_Steering_Tiller_Template">
 			<NODE_ID>HANDLE_LEFT_YOKE</NODE_ID>
 			<ANIM_NAME>HANDLE_LEFT_YOKE</ANIM_NAME>
@@ -690,7 +690,7 @@
 			<ANIM_NAME>HANDLE_RIGHT_YOKE</ANIM_NAME>
 			<MAX_STEERING_VELOCITY>30</MAX_STEERING_VELOCITY>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 			<NODE_ID>PUSH_HANDLE_LEFT_YOKE</NODE_ID>
 			<POTENTIOMETER>15</POTENTIOMETER>
@@ -699,21 +699,21 @@
 			<NODE_ID>PUSH_HANDLE_RIGHT_YOKE</NODE_ID>
 			<POTENTIOMETER>15</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<!-- NYI
 		<UseTemplate Name="ASOBO_AIRBUS_Push_Transfer_Template">
 			<NODE_ID>PUSH_EFIS_CS_PFD</NODE_ID>
 			<ANIM_NAME>PUSH_EFIS_CS_PFD</ANIM_NAME>
 			<ID>1</ID>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_Transfer_Template">
 			<NODE_ID>PUSH_EFIS_FO_PFD</NODE_ID>
 			<ANIM_NAME>PUSH_EFIS_FO_PFD</ANIM_NAME>
 			<ID>2</ID>
 		</UseTemplate>
 		-->
-		
+
 		<Component ID="Screens_Left">
 			<UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
 				<POTENTIOMETER>18</POTENTIOMETER>
@@ -723,12 +723,12 @@
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_L_PFD_DECREASE</ANIMTIP_0>
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_L_PFD_INCREASE</ANIMTIP_0>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 				<NODE_ID>SCREEN_PFD_L</NODE_ID>
 				<POTENTIOMETER>18</POTENTIOMETER>
-			</UseTemplate>	
-			
+			</UseTemplate>
+
 			<UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
 				<POTENTIOMETER>19</POTENTIOMETER>
 				<NODE_ID>KNOB_EFIS_CS_ND</NODE_ID>
@@ -737,13 +737,13 @@
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_L_ND_DECREASE</ANIMTIP_0>
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_L_ND_INCREASE</ANIMTIP_0>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 				<NODE_ID>SCREEN_MFD_L</NODE_ID>
 				<POTENTIOMETER>19</POTENTIOMETER>
-			</UseTemplate>	
+			</UseTemplate>
 		</Component>
-		
+
 		<Component ID="Screens_Right">
 			<UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
 				<POTENTIOMETER>20</POTENTIOMETER>
@@ -753,12 +753,12 @@
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_R_PFD_DECREASE</ANIMTIP_0>
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_R_PFD_INCREASE</ANIMTIP_0>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 				<NODE_ID>SCREEN_PFD_R</NODE_ID>
 				<POTENTIOMETER>20</POTENTIOMETER>
-			</UseTemplate>	
-			
+			</UseTemplate>
+
 			<UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
 				<POTENTIOMETER>21</POTENTIOMETER>
 				<NODE_ID>KNOB_EFIS_FO_ND</NODE_ID>
@@ -767,14 +767,14 @@
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_R_ND_DECREASE</ANIMTIP_0>
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHTING_KNOB_R_ND_INCREASE</ANIMTIP_0>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 				<NODE_ID>SCREEN_MFD_R</NODE_ID>
 				<POTENTIOMETER>21</POTENTIOMETER>
 			</UseTemplate>
-		</Component>	
+		</Component>
 	</Component>
-	
+
 	<Component ID="Front_Middle">
 		<UseTemplate Name="ASOBO_LANDING_GEAR_Lever_Gear_Template">
 			<ANIM_NAME>lever_landing_gear</ANIM_NAME>
@@ -825,42 +825,42 @@
 			<MIN_DECEL_FPSS>-21</MIN_DECEL_FPSS>
 			<OFF_TOOLTIP>COCKPIT.TOOLTIPS.AUTO_BRK_SET_MAX</OFF_TOOLTIP>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_HANDLING_Switch_AntiSkid_Template">
 			<NODE_ID>SWITCH_AUTOBKR_ASKID</NODE_ID>
 			<ANIM_NAME>SWITCH_AUTOBKR_ASKID</ANIM_NAME>
 			<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.ANTISKID_TURN_ON</ANIMTIP_0>
 			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.ANTISKID_TURN_OFF</ANIMTIP_1>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_TERRONND_Template">
 			<NODE_ID>PUSH_TERRONND</NODE_ID>
 			<ANIM_NAME>PUSH_TERRONND</ANIM_NAME>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_TERRONND_Template">
 			<NODE_ID>PUSH_AUTOBKR_TERRONND</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOBKR_TERRONND</ANIM_NAME>
 		</UseTemplate>
-		
+
 		<Component ID="Standby_Indicator">
-			
+
 			<UseTemplate Name="ASOBO_AUTOPILOT_Knob_Baro_Template">
 				<ANIM_NAME>AUTOPILOT_Knob_Baro</ANIM_NAME>
 				<NODE_ID>AUTOPILOT_Knob_Baro</NODE_ID>
 				<ID>3</ID>
 				<BARO_ID>2</BARO_ID>
-				
+
 				<ANIMREF_ID>-1</ANIMREF_ID>
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.STBY_TUNING_KNOB_INCREASE</ANIMTIP_0>
 				<ANIMTIP_0_ON_CURSOR>TurnRight</ANIMTIP_0_ON_CURSOR>
 				<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.STBY_TUNING_KNOB_DECREASE</ANIMTIP_1>
 				<ANIMTIP_1_ON_CURSOR>TurnLeft</ANIMTIP_1_ON_CURSOR>
 
-				
+
 			</UseTemplate>
 		</Component>
-		
+
 		<Component ID="Dummies">
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_AUTOPILOT_SIDESTICK_L</NODE_ID>
@@ -884,13 +884,13 @@
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_EFIS_FO_GPWS</NODE_ID>
 			</UseTemplate>
-			
+
 			<Component ID="BARO">
 				<DefaultTemplateParameters>
 					<POTENTIOMETER_SEQ1>15</POTENTIOMETER_SEQ1>
 					<SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
 				</DefaultTemplateParameters>
-				
+
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_BARO_BUGS</NODE_ID>
 					<ONLY_SEQ1/>
@@ -917,7 +917,7 @@
 					<POTENTIOMETER_SEQ1>15</POTENTIOMETER_SEQ1>
 					<SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
 				</DefaultTemplateParameters>
-			
+
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>SWITCH_MPL_DIM</NODE_ID>
 					<ONLY_SEQ1/>
@@ -959,7 +959,7 @@
 					<ONLY_SEQ1/>
 				</UseTemplate>
 			</Component>
-			
+
 			<Component ID="MPR">
 				<DefaultTemplateParameters>
 					<POTENTIOMETER_SEQ1>15</POTENTIOMETER_SEQ1>
@@ -1007,7 +1007,7 @@
 				</UseTemplate>
 			</Component>
 		</Component>
-		
+
 		<Component ID="EICAS_Screens">
 			<UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
 				<POTENTIOMETER>22</POTENTIOMETER>
@@ -1020,7 +1020,7 @@
 			<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 				<NODE_ID>SCREEN_EICAS1</NODE_ID>
 				<POTENTIOMETER>22</POTENTIOMETER>
-			</UseTemplate>	
+			</UseTemplate>
 			<UseTemplate Name="ASOBO_LIGHTING_Knob_Potentiometer_Template">
 				<POTENTIOMETER>23</POTENTIOMETER>
 				<NODE_ID>KNOB_ECAM_LOWER</NODE_ID>
@@ -1032,10 +1032,10 @@
 			<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 				<NODE_ID>SCREEN_EICAS2</NODE_ID>
 				<POTENTIOMETER>23</POTENTIOMETER>
-			</UseTemplate>	
+			</UseTemplate>
 		</Component>
 	</Component>
-	
+
 	<Component ID="OVERHEAD">
 		<Component ID="OVERHEAD_Electricals">
 			<DefaultTemplateParameters>
@@ -1055,7 +1055,7 @@
 				<BATTERY_BUS_ID>11</BATTERY_BUS_ID>
 				<HOT_BATTERY_BUS_ID>6</HOT_BATTERY_BUS_ID>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_ELECTRICAL_Switch_Alternator_Template">
 				<NODE_ID>PUSH_OVHD_ELEC_GEN1</NODE_ID>
 				<ANIM_NAME>PUSH_OVHD_ELEC_GEN1</ANIM_NAME>
@@ -1100,7 +1100,7 @@
 				<ANIM_NAME>KNOB_OVHD_AIRCOND_PACKFLOW</ANIM_NAME>
 				<ANIM_CODE>50</ANIM_CODE>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Fuel_Valve_Template">
 				<NODE_ID>PUSH_OVHD_APU_MASTERSW</NODE_ID>
 				<ANIM_NAME>PUSH_OVHD_APU_MASTERSW</ANIM_NAME>
@@ -1115,14 +1115,14 @@
 				<OFF_TOOLTIP>COCKPIT.TOOLTIPS.APU_SWITCH_TURN_ON</OFF_TOOLTIP>
 				<ON_TOOLTIP>COCKPIT.TOOLTIPS.APU_SWITCH_TURN_OFF</ON_TOOLTIP>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_ELECTRICAL_Switch_APU_Starter_Template">
 				<NODE_ID>PUSH_OVHD_APU_START</NODE_ID>
 				<ANIM_NAME>PUSH_OVHD_APU_START</ANIM_NAME>
 				<EXTRA_CONDITION>(L:APU_FLAP_OPEN, Bool)</EXTRA_CONDITION>
 			</UseTemplate>
 		</Component>
-		
+
 		<Component ID="OVERHEAD_Lights">
 			<!-- Lights -->
 			<UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Strobe_Template">
@@ -1147,7 +1147,7 @@
 				<NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
 				<NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
 			</UseTemplate>
-			
+
 			<!-- TODO: No Smoking Light DUMMY : Find a way to set the start value?-->
 			<UseTemplate Name="ASOBO_GT_Switch_Dummy">
 				<NODE_ID>SWITCH_OVHD_INTLT_NOSMOKING</NODE_ID>
@@ -1165,7 +1165,7 @@
 				<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.LIGHTS_NOSMOKING_ON</ANIMTIP_2>
 				<WWISE_EVENT>double_light_switch</WWISE_EVENT>
 			</UseTemplate>
-			
+
 			<!-- TODO: Emergency Exit Light DUMMY : Find a way to set the start value? -->
 			<UseTemplate Name="ASOBO_GT_Switch_Dummy">
 				<NODE_ID>SWITCH_OVHD_INTLT_EMEREXIT</NODE_ID>
@@ -1181,7 +1181,7 @@
 				<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.LIGHTS_EMEREXIT_OFF</ANIMTIP_2>
 				<WWISE_EVENT>double_light_switch</WWISE_EVENT>
 			</UseTemplate>
-			
+
 			<!-- TODO: ANN Light DUMMY : Find a way to set the start value? -->
 			<UseTemplate Name="ASOBO_GT_Switch_Dummy">
 				<NODE_ID>SWITCH_OVHD_INTLT_ANNLT</NODE_ID>
@@ -1211,12 +1211,12 @@
 				<NORMALIZED_TIME_1>0.1</NORMALIZED_TIME_1>
 				<NORMALIZED_TIME_2>0.5</NORMALIZED_TIME_2>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Beacon_Template">
 				<NODE_ID>SWITCH_OVHD_EXTLT_BEACON</NODE_ID>
 				<ANIM_NAME>SWITCH_OVHD_EXTLT_BEACON</ANIM_NAME>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Taxi_Template">
 				<NODE_ID>SWITCH_OVHD_EXTLT_RWY</NODE_ID>
 				<ANIM_NAME>SWITCH_OVHD_EXTLT_RWY</ANIM_NAME>
@@ -1226,7 +1226,7 @@
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.RWY_TURNOFF_LIGHTS_OFF</ANIMTIP_0>
 				<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.RWY_TURNOFF_LIGHTS_ON</ANIMTIP_1>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Landing_Template">
 				<NODE_ID>SWITCH_OVHD_EXTLT_LANDL</NODE_ID>
 				<ANIM_NAME>SWITCH_OVHD_EXTLT_LANDL</ANIM_NAME>
@@ -1237,7 +1237,7 @@
 				<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.LANDING_LIGHT_L_RETRACT</ANIMTIP_2>
 				<RETRACTABLE/>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Landing_Template">
 				<NODE_ID>SWITCH_OVHD_EXTLT_LANDR</NODE_ID>
 				<ANIM_NAME>SWITCH_OVHD_EXTLT_LANDR</ANIM_NAME>
@@ -1248,7 +1248,7 @@
 				<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LANDING_LIGHT_R_ON</ANIMTIP_1>
 				<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.LANDING_LIGHT_R_RETRACT</ANIMTIP_2>
 			</UseTemplate>
-		
+
 			<UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Wing_Template">
 				<NODE_ID>SWITCH_OVHD_EXTLT_WING</NODE_ID>
 				<ANIM_NAME>SWITCH_OVHD_EXTLT_WING</ANIM_NAME>
@@ -1285,7 +1285,7 @@
 					(A:CIRCUIT CONNECTION ON:20, Bool) l0 != if{ 20 2 (&gt;K:2:ELECTRICAL_BUS_TO_CIRCUIT_CONNECTION_TOGGLE) }
 				</UPDATE_CODE>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_LIGHTING_Knob_Panel_Template">
 				<NODE_ID>KNOB_OVHD_INTLT_BRT</NODE_ID>
 				<ANIM_NAME>KNOB_OVHD_INTLT_BRT</ANIM_NAME>
@@ -1297,13 +1297,13 @@
 				<ANIMTIP_0>TT:COCKPIT.TOOLTIPS.LIGHT_OVHD_PANEL_SUBPANEL_DECREASE</ANIMTIP_0>
 				<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.LIGHT_OVHD_PANEL_SUBPANEL_INCREASE</ANIMTIP_1>
 			</Component>
-			
+
 			<UseTemplate Name="ASOBO_LIGHTING_Panel_Emissive_Template">
 				<NODE_ID>LIGHTS_OVHD</NODE_ID>
 				<SIMVAR_INDEX>4</SIMVAR_INDEX>
 				<POTENTIOMETER>16</POTENTIOMETER>
 			</Component>
-			
+
 			<UseTemplate Name="ASOBO_LIGHTING_Switch_Light_Cabin_Template">
 				<POTENTIOMETER>7</POTENTIOMETER>
 				<DIMMER/>
@@ -1318,14 +1318,14 @@
 				<ANIMCURSOR_MIN>0</ANIMCURSOR_MIN>
 				<ANIMCURSOR_MAX>1</ANIMCURSOR_MAX>
 			</Component>
-			
+
 			<UseTemplate Name="ASOBO_LIGHTING_Cabin_Emissive_Template">
 				<NODE_ID>LIGHTS_Overhead</NODE_ID>
 				<POTENTIOMETER>7</POTENTIOMETER>
 			</Component>
 			<CameraTitle>Overhead</CameraTitle>
 		</Component>
-		
+
 		<Component ID="Overhead_Fuel">
 			<DefaultTemplateParameters>
 				<TYPE>AIRBUS</TYPE>
@@ -1335,7 +1335,7 @@
 				<ANIM_NAME>PUSH_OVHD_FUEL_XFEED</ANIM_NAME>
 				<ID>1</ID>
 				<OFF_TOOLTIP>COCKPIT.TOOLTIPS.FUEL_XFEED_TURN_ON</OFF_TOOLTIP>
-				<ON_TOOLTIP>COCKPIT.TOOLTIPS.FUEL_XFEED_TURN_OFF</ON_TOOLTIP>				
+				<ON_TOOLTIP>COCKPIT.TOOLTIPS.FUEL_XFEED_TURN_OFF</ON_TOOLTIP>
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_FUEL_Push_Pump_Template">
 				<NODE_ID>PUSH_OVHD_FUEL_LTKPUMPS1</NODE_ID>
@@ -1363,7 +1363,7 @@
 				<ANIM_NAME>PUSH_OVHD_FUEL_PUMP2</ANIM_NAME>
 				<ID>4</ID>
 				<OFF_TOOLTIP>COCKPIT.TOOLTIPS.CTR_TK_PUMP_2_OFF</OFF_TOOLTIP>
-				<ON_TOOLTIP>COCKPIT.TOOLTIPS.CTR_TK_PUMP_2_ON</ON_TOOLTIP>				
+				<ON_TOOLTIP>COCKPIT.TOOLTIPS.CTR_TK_PUMP_2_ON</ON_TOOLTIP>
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_FUEL_Push_Pump_Template">
 				<NODE_ID>PUSH_OVHD_FUEL_RTKPUMPS1</NODE_ID>
@@ -1388,7 +1388,7 @@
 				</SEQ1_EMISSIVE_CODE>
 			</UseTemplate>
 		</Component>
-		
+
 		<Component ID="OverHead_Flight_Controls">
 			<UseTemplate Name="ASOBO_AIRBUS_Push_ELAC_Template">
 				<NODE_ID>PUSH_OVHD_FLTCTL_ELAC</NODE_ID>
@@ -1399,7 +1399,7 @@
 				<NODE_ID>PUSH_OVHD_FLTCTL_SEC</NODE_ID>
 				<ANIM_NAME>PUSH_OVHD_FLTCTL_SEC</ANIM_NAME>
 				<ID>1</ID>
-				
+
 			</UseTemplate>
 			<UseTemplate Name="ASOBO_AIRBUS_Push_FAC_Template">
 				<NODE_ID>PUSH_OVHD_FLTCTL_FAC</NODE_ID>
@@ -1410,24 +1410,24 @@
 				<NODE_ID>PUSH_OVHD_FLTCTL_ELAC2</NODE_ID>
 				<ANIM_NAME>PUSH_OVHD_FLTCTL_ELAC2</ANIM_NAME>
 				<ID>2</ID>
-			</UseTemplate>	
+			</UseTemplate>
 			<UseTemplate Name="ASOBO_AIRBUS_Push_SEC_Template">
 				<NODE_ID>PUSH_OVHD_FLTCTL_SEC2</NODE_ID>
 				<ANIM_NAME>PUSH_OVHD_FLTCTL_SEC2</ANIM_NAME>
 				<ID>2</ID>
-			</UseTemplate>				
+			</UseTemplate>
 			<UseTemplate Name="ASOBO_AIRBUS_Push_SEC_Template">
 				<NODE_ID>PUSH_OVHD_FLTCTL_SEC3</NODE_ID>
 				<ANIM_NAME>PUSH_OVHD_FLTCTL_SEC3</ANIM_NAME>
 				<ID>3</ID>
-			</UseTemplate>			
+			</UseTemplate>
 			<UseTemplate Name="ASOBO_AIRBUS_Push_FAC_Template">
 				<NODE_ID>PUSH_OVHD_FLTCTL_FAC2</NODE_ID>
 				<ANIM_NAME>PUSH_OVHD_FLTCTL_FAC2</ANIM_NAME>
 				<ID>2</ID>
-			</UseTemplate>	
+			</UseTemplate>
 		</Component>
-		
+
 		<Component ID="Overhead_Dummies">
 			<Component ID="Left_Column">
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
@@ -1450,7 +1450,7 @@
 					<ID>3</ID>
 					<NODE_ID>PUSH_OVHD_ADIRS_IR3</NODE_ID>
 				</UseTemplate>
-				
+
 				<UseTemplate Name="ASOBO_AIRLINER_ADIRS_Knob_Template">
 					<ID>1</ID>
 					<ANIM_CODE>50</ANIM_CODE>
@@ -1573,7 +1573,7 @@
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_ELEC_IDG2</NODE_ID>
 				</UseTemplate>
-		
+
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_AIRCOND_PACK1</NODE_ID>
 				</UseTemplate>
@@ -1624,61 +1624,61 @@
 				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_HYD_G</NODE_ID>
-				</UseTemplate>	
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_HYD_B</NODE_ID>
-				</UseTemplate>	
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_HYD_Y</NODE_ID>
-				</UseTemplate>	
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_APU_AUTOEXITING_TEST</NODE_ID>
-				</UseTemplate>	
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_ENG_FADEC1</NODE_ID>
-				</UseTemplate>		
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_ENG_FADEC2</NODE_ID>
-				</UseTemplate>		
-		
+				</UseTemplate>
+
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_CARGOVENT_AFTISOL</NODE_ID>
-				</UseTemplate>	
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_CARGOSMOKE_FWD1</NODE_ID>
 					<ONLY_SEQ1/>
-				</UseTemplate>		
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_CARGOSMOKE_FWD2</NODE_ID>
 					<ONLY_SEQ1/>
-				</UseTemplate>	
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_VENTILATION_BLOWER</NODE_ID>
-				</UseTemplate>	
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_VENTILATION_EXTRACT</NODE_ID>
-				</UseTemplate>	
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_VENTILATION_CABFANS</NODE_ID>
-				</UseTemplate>	
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_ENGMANSTART_1</NODE_ID>
-				</UseTemplate>				
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_ENGMANSTART_2</NODE_ID>
-				</UseTemplate>			
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_ENGN1MODE_1</NODE_ID>
-				</UseTemplate>		
+				</UseTemplate>
 				<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 					<NODE_ID>PUSH_OVHD_ENGN1MODE_2</NODE_ID>
 				</UseTemplate>
-				
+
 				<Component ID="Overhead_Audio_Panel">
 					<OverrideTemplateParameters>
 						<EMISSIVE_CODE>0</EMISSIVE_CODE>
 					</OverrideTemplateParameters>
-					
+
 					<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 						<NODE_ID>PUSH_OVHD_RADIO_VOR1</NODE_ID>
 					</UseTemplate>
@@ -1762,7 +1762,7 @@
 				</UseTemplate>
 			</Component>
 		</Component>
-		
+
 		<Component ID="OverHead_AntiIce">
 			<UseTemplate Name="ASOBO_DEICE_Switch_Engine_Template">
 				<NODE_ID>PUSH_OVHD_ANTIICE_ENG1</NODE_ID>
@@ -1791,7 +1791,7 @@
 				<SWITCH_TYPE>AIRBUS</SWITCH_TYPE>
 			</UseTemplate>
 		</Component>
-		
+
 		<Component ID="Overhead_Handling">
 			<UseTemplate Name="ASOBO_HANDLING_Switch_Wipers_Template">
 				<CIRCUIT_ID_WIPERS>77</CIRCUIT_ID_WIPERS>
@@ -1808,7 +1808,7 @@
 			<SEQ2_EMISSIVE_DRIVES_VISIBILITY>False</SEQ2_EMISSIVE_DRIVES_VISIBILITY>
 			<DEFAULT_TEMPLATE_EMISSIVE>ASOBO_LIGHTING_Potentiometer_Emissive_Template</DEFAULT_TEMPLATE_EMISSIVE>
 		</DefaultTemplateParameters>
-	
+
 		<UseTemplate Name="ASOBO_AIRLINER_Switch_Baro_Selector_Template">
 			<NODE_ID>KNOB_AUTOPILOT_SELECTOR_L1</NODE_ID>
 			<ANIM_NAME>KNOB_AUTOPILOT_SELECTOR_L1</ANIM_NAME>
@@ -1817,7 +1817,7 @@
 			<NODE_ID>KNOB_AUTOPILOT_SELECTOR_R1</NODE_ID>
 			<ANIM_NAME>KNOB_AUTOPILOT_SELECTOR_R1</ANIM_NAME>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Knob_Baro_Template">
 			<NODE_ID>KNOB_AUTOPILOT_KNOB1_L</NODE_ID>
 			<ANIM_NAME_KNOB>KNOB_AUTOPILOT_KNOB1_L</ANIM_NAME_KNOB>
@@ -1830,7 +1830,7 @@
 			<ANIM_NAME_PUSHPULL>PUSH_AUTOPILOT_KNOB1_R</ANIM_NAME_PUSHPULL>
 			<AIRLINER_TYPE>A320</AIRLINER_TYPE>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_FlightDirector_Template">
 			<NODE_ID>PUSH_AUTOPILOT_FD_L</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_FD_L</ANIM_NAME>
@@ -1839,7 +1839,7 @@
 			<POTENTIOMETER>14</POTENTIOMETER>
 			<ID>1</ID>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_FlightDirector_Template">
 			<NODE_ID>PUSH_AUTOPILOT_FD_R</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_FD_R</ANIM_NAME>
@@ -1848,103 +1848,103 @@
 			<POTENTIOMETER>14</POTENTIOMETER>
 			<ID>1</ID>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_ILS_Template">
 			<NODE_ID>PUSH_AUTOPILOT_LS_L</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_LS_L</ANIM_NAME>
 			<POTENTIOMETER>14</POTENTIOMETER>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_ILS_Template">
 			<NODE_ID>PUSH_AUTOPILOT_LS_R</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_LS_R</ANIM_NAME>
 			<POTENTIOMETER>14</POTENTIOMETER>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRLINER_Knob_ND_Template">
 			<TYPE>AIRBUS</TYPE>
 			<NODE_ID>KNOB_AUTOPILOT_ROSE_L</NODE_ID>
 			<ANIM_NAME>KNOB_AUTOPILOT_ROSE_L_</ANIM_NAME>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AIRLINER_Knob_ND_Range_Template">
 			<TYPE>AIRBUS</TYPE>
 			<NODE_ID>KNOB_AUTOPILOT_L1</NODE_ID>
 			<ANIM_NAME>KNOB_AUTOPILOT_L1</ANIM_NAME>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRLINER_Knob_ND_Template">
 			<TYPE>AIRBUS</TYPE>
 			<NODE_ID>KNOB_AUTOPILOT_ROSE_R</NODE_ID>
 			<ANIM_NAME>KNOB_AUTOPILOT_ROSE_R</ANIM_NAME>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AIRLINER_Knob_ND_Range_Template">
 			<TYPE>AIRBUS</TYPE>
 			<NODE_ID>KNOB_AUTOPILOT_R1</NODE_ID>
 			<ANIM_NAME>KNOB_AUTOPILOT_R1</ANIM_NAME>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_CSTR_Template">
 			<NODE_ID>PUSH_AUTOPILOT_CSTR_L</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_CSTR_L</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_VORD_Template">
 			<NODE_ID>PUSH_AUTOPILOT_VORD_L</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_VORD_L</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_WPT_Template">
 			<NODE_ID>PUSH_AUTOPILOT_WPT_L</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_WPT_L</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_NDB_Template">
 			<NODE_ID>PUSH_AUTOPILOT_NDB_L</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_NDB_L</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_ARPT_Template">
 			<NODE_ID>PUSH_AUTOPILOT_ARPT_L</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_ARPT_L</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_CSTR_Template">
 			<NODE_ID>PUSH_AUTOPILOT_CSTR_R</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_CSTR_R</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_VORD_Template">
 			<NODE_ID>PUSH_AUTOPILOT_VORD_R</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_VORD_R</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_WPT_Template">
 			<NODE_ID>PUSH_AUTOPILOT_WPT_R</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_WPT_R</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_NDB_Template">
 			<NODE_ID>PUSH_AUTOPILOT_NDB_R</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_NDB_R</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_ARPT_Template">
 			<NODE_ID>PUSH_AUTOPILOT_ARPT_R</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_ARPT_R</ANIM_NAME>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_SpeedToggle_Template">
 			<NODE_ID>PUSH_AUTOPILOT_SPDMACH_L</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_SPDMACH_L</ANIM_NAME>
@@ -1952,14 +1952,14 @@
 			<NO_TEXT_EMISSIVE>True</NO_TEXT_EMISSIVE>
 
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Knob_SpeedMach_Template">
 			<NODE_ID>KNOB_AUTOPILOT_L2</NODE_ID>
 			<ANIM_NAME>KNOB_AUTOPILOT_L2</ANIM_NAME>
 			<ANIM_NAME_PUSHPULL>PUSH_AUTOPILOT_L2</ANIM_NAME_PUSHPULL>
 			<TYPE>AIRBUS</TYPE>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Knob_Heading_Template">
 			<NODE_ID>KNOB_AUTOPILOT_L3</NODE_ID>
 			<ANIM_NAME_KNOB>KNOB_AUTOPILOT_L3</ANIM_NAME_KNOB>
@@ -1969,9 +1969,9 @@
 			<ANIMTIP_2_ON_CURSOR>UpArrow</ANIMTIP_2_ON_CURSOR>
 			<ANIMTIP_3>TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_HDG_ENGAGE_SELECTED_HEADING_MODE</ANIMTIP_3>
 			<ANIMTIP_3_ON_CURSOR>DownArrow</ANIMTIP_3_ON_CURSOR>
-			
+
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_Localizer_Template">
 			<NODE_ID>PUSH_AUTOPILOT_LOC</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_LOC</ANIM_NAME>
@@ -1979,18 +1979,18 @@
 			<ACTIVE_NODE_ID>PUSH_AUTOPILOT_LOC_SEQ1</ACTIVE_NODE_ID>
 			<EMISSIVE_NODE_ID>PUSH_AUTOPILOT_LOC_SEQ2</EMISSIVE_NODE_ID>
 		</UseTemplate>
-		
+
 		<!--
 		<UseTemplate Name="ASOBO_AIRBUS_Push_Heading_Track_Template">
 			<NODE_ID>PUSH_AUTOPILOT_HDGTRK</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_HDGTRK</ANIM_NAME>
-		</UseTemplate>	
+		</UseTemplate>
 		-->
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Update_Autopilot_Match_Simvar">
 			<AP_COUNT>2</AP_COUNT>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_Autopilot_Template">
 			<NODE_ID>PUSH_AUTOPILOT_AP1</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_AP1</ANIM_NAME>
@@ -1999,9 +1999,9 @@
 			<EMISSIVE_NODE_ID>PUSH_AUTOPILOT_AP1_SEQ2</EMISSIVE_NODE_ID>
 			<ID>1</ID>
 			<AP_COUNT>2</AP_COUNT>
-			<TYPE>EXCLUSIVE_AP</TYPE>
+			<!-- <TYPE>EXCLUSIVE_AP</TYPE> -->
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_Autopilot_Template">
 			<NODE_ID>PUSH_AUTOPILOT_AP2</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_AP2</ANIM_NAME>
@@ -2010,9 +2010,9 @@
 			<EMISSIVE_NODE_ID>PUSH_AUTOPILOT_AP2_SEQ2</EMISSIVE_NODE_ID>
 			<ID>2</ID>
 			<AP_COUNT>2</AP_COUNT>
-			<TYPE>EXCLUSIVE_AP</TYPE>
+			<!-- <TYPE>EXCLUSIVE_AP</TYPE> -->
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_AutoThrottle_Template">
 			<NODE_ID>PUSH_AUTOPILOT_ATHR</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_ATHR</ANIM_NAME>
@@ -2020,7 +2020,7 @@
 			<ACTIVE_NODE_ID>PUSH_AUTOPILOT_ATHR_SEQ1</ACTIVE_NODE_ID>
 			<EMISSIVE_NODE_ID>PUSH_AUTOPILOT_ATHR_SEQ2</EMISSIVE_NODE_ID>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_Approach_Template">
 			<NODE_ID>PUSH_AUTOPILOT_APPR</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_APPR</ANIM_NAME>
@@ -2029,26 +2029,26 @@
 			<EMISSIVE_NODE_ID>PUSH_AUTOPILOT_APPR_SEQ2</EMISSIVE_NODE_ID>
 			<DISABLE_GPS_MODE>False</DISABLE_GPS_MODE>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_Expedite_Template">
 			<NODE_ID>PUSH_AUTOPILOT_EXPED</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_EXPED</ANIM_NAME>
 			<ACTIVE_NODE_ID>PUSH_AUTOPILOT_EXPED_SEQ1</ACTIVE_NODE_ID>
 			<EMISSIVE_NODE_ID>PUSH_AUTOPILOT_EXPED_SEQ2</EMISSIVE_NODE_ID>
 			<POTENTIOMETER_SEQ2>14</POTENTIOMETER_SEQ2>
-		</UseTemplate>	
-		
+		</UseTemplate>
+
 		<UseTemplate Name="ASOBO_AIRBUS_Push_Metric_Alt_Template">
 			<NODE_ID>PUSH_AUTOPILOT_METRICALT</NODE_ID>
 			<ANIM_NAME>PUSH_AUTOPILOT_METRICALT</ANIM_NAME>
-		</UseTemplate>	
-		
+		</UseTemplate>
+
 		<UseTemplate Name="ASOBO_AIRBUS_Switch_Altitude_Increment_Template">
 			<NODE_ID>KNOB_AUTOPILOT_SELECTOR_ALT</NODE_ID>
 			<ANIM_NAME>KNOB_AUTOPILOT_SELECTOR_ALT</ANIM_NAME>
-			
+
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Knob_Altitude_Template">
 			<NODE_ID>KNOB_AUTOPILOT_KNOB_ALT</NODE_ID>
 			<ANIM_NAME_KNOB>KNOB_AUTOPILOT_ALT</ANIM_NAME_KNOB>
@@ -2060,11 +2060,11 @@
 			<ANIMTIP_1_ON_CURSOR>TurnRight</ANIMTIP_1_ON_CURSOR>
 			<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_ENGAGE_MANAGED_ALTITUDE_MODE</ANIMTIP_2>
 			<ANIMTIP_2_ON_CURSOR>UpArrow</ANIMTIP_2_ON_CURSOR>
-			<ANIMTIP_3>TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_ENGAGE_SELECTED_ALTITUDE_MODE</ANIMTIP_3>	
+			<ANIMTIP_3>TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_ENGAGE_SELECTED_ALTITUDE_MODE</ANIMTIP_3>
 			<ANIMTIP_3_ON_CURSOR>DownArrow</ANIMTIP_3_ON_CURSOR>
 			<TYPE>AIRBUS</TYPE>
 		</UseTemplate>
-	
+
 		<UseTemplate Name="ASOBO_AUTOPILOT_Knob_VerticalSpeed_Template">
 			<NODE_ID>KNOB_AUTOPILOT_UPDN</NODE_ID>
 			<ANIM_NAME_KNOB>KNOB_AUTOPILOT_UPDN</ANIM_NAME_KNOB>
@@ -2078,9 +2078,9 @@
 			<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_LEVEL_OFF</ANIMTIP_2>
 			<ANIMTIP_2_ON_CURSOR>UpArrow</ANIMTIP_2_ON_CURSOR>
 			<ANIMTIP_3>TT:COCKPIT.TOOLTIPS.AUTOPILOT_PANEL_VS_FPA_ENGAGE</ANIMTIP_3>
-			<ANIMTIP_3_ON_CURSOR>DownArrow</ANIMTIP_3_ON_CURSOR>			
+			<ANIMTIP_3_ON_CURSOR>DownArrow</ANIMTIP_3_ON_CURSOR>
 		</UseTemplate>
-			
+
 		<UseTemplate Name="ASOBO_AIRBUS_NAV_AID_SWITCH_Template">
 			<BASE_NAME>SWITCH_AUTOPILOT_ADF1_L</BASE_NAME>
 			<STATE_VAR_NAME>XMLVAR_NAV_AID_SWITCH_L1_State</STATE_VAR_NAME>
@@ -2088,7 +2088,7 @@
 			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.EFIS_PANEL_ADFSWITCH_OFF1</ANIMTIP_1>
 			<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.EFIS_PANEL_ADFSWITCH_VOR1</ANIMTIP_2>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AIRBUS_NAV_AID_SWITCH_Template">
 			<BASE_NAME>SWITCH_AUTOPILOT_ADF2_L</BASE_NAME>
 			<STATE_VAR_NAME>XMLVAR_NAV_AID_SWITCH_L2_State</STATE_VAR_NAME>
@@ -2096,7 +2096,7 @@
 			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.EFIS_PANEL_ADFSWITCH_OFF2</ANIMTIP_1>
 			<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.EFIS_PANEL_ADFSWITCH_VOR2</ANIMTIP_2>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AIRBUS_NAV_AID_SWITCH_Template">
 			<BASE_NAME>SWITCH_AUTOPILOT_ADF1_R</BASE_NAME>
 			<STATE_VAR_NAME>XMLVAR_NAV_AID_SWITCH_R1_State</STATE_VAR_NAME>
@@ -2104,7 +2104,7 @@
 			<ANIMTIP_1>TT:COCKPIT.TOOLTIPS.EFIS_PANEL_ADFSWITCH_OFF1</ANIMTIP_1>
 			<ANIMTIP_2>TT:COCKPIT.TOOLTIPS.EFIS_PANEL_ADFSWITCH_VOR1</ANIMTIP_2>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_AIRBUS_NAV_AID_SWITCH_Template">
 			<BASE_NAME>SWITCH_AUTOPILOT_ADF2_R</BASE_NAME>
 			<STATE_VAR_NAME>XMLVAR_NAV_AID_SWITCH_R2_State</STATE_VAR_NAME>
@@ -2119,54 +2119,54 @@
 			<BOTH_SCREENS_ON_ONE_NODE/>
 			<NODE_ID>DYN_SCREEN</NODE_ID>
 		</UseTemplate>
-		
+
 		<UseTemplate Name="ASOBO_ECAM_PAGE_SELECTION_Template">
 			<POTENTIOMETER>15</POTENTIOMETER>
 		</UseTemplate>
-		
+
 		<Component ID="ECAM_Push_Dummies">
 			<DefaultTemplateParameters>
 				<SEQ1_EMISSIVE_DRIVES_VISIBILITY>False</SEQ1_EMISSIVE_DRIVES_VISIBILITY>
 				<SEQ2_EMISSIVE_DRIVES_VISIBILITY>False</SEQ2_EMISSIVE_DRIVES_VISIBILITY>
 			</DefaultTemplateParameters>
-			
+
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_ECAM_TOCONFIG</NODE_ID>
 				<POTENTIOMETER_SEQ1>15</POTENTIOMETER_SEQ1>
 				<ONLY_SEQ1/>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_ECAM_ALL</NODE_ID>
 				<POTENTIOMETER_SEQ1>15</POTENTIOMETER_SEQ1>
 				<ONLY_SEQ1/>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_ECAM_CLR</NODE_ID>
 				<POTENTIOMETER_SEQ1>15</POTENTIOMETER_SEQ1>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_ECAM_STS</NODE_ID>
 				<POTENTIOMETER_SEQ1>15</POTENTIOMETER_SEQ1>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_ECAM_RCL</NODE_ID>
 				<POTENTIOMETER_SEQ1>15</POTENTIOMETER_SEQ1>
 				<ONLY_SEQ1/>
 			</UseTemplate>
-			
+
 			<UseTemplate Name="ASOBO_AIRBUS_Push_Dummy_Template">
 				<NODE_ID>PUSH_ECAM_CLR2</NODE_ID>
 				<POTENTIOMETER_SEQ1>15</POTENTIOMETER_SEQ1>
 			</UseTemplate>
 		</Component>
-		
+
 		<CameraTitle>MFD</CameraTitle>
 	</Component>
-	
+
 	<Component ID="Airbus_FDW">
 		<DefaultTemplateParameters>
 			<POTENTIOMETER>15</POTENTIOMETER>
@@ -2241,7 +2241,7 @@
 				</UseTemplate>
 			</Component>
 		</Component>
-		
+
 		<Component ID="Radio_Right">
 			<UseTemplate Name="ASOBO_RMP_DISPLAY_Template">
 				<SIDE>R</SIDE>
@@ -2308,7 +2308,7 @@
 			</Component>
 		</Component>
 	</Component>
-	
+
 	<Component ID="Airbus_ATC">
 		<UseTemplate Name="ASOBO_AIRLINER_ATC_Template">
 			<TYPE>AIRBUS</TYPE>
@@ -2323,18 +2323,18 @@
 
 	<Component ID="Airbus_Pedestal_Radios">
 		<Component ID="Radio_Left">
-			
+
 			<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 				<NODE_ID>SCREEN_COM_L</NODE_ID>
 				<EMISSIVE_CODE>0.5</EMISSIVE_CODE> <!-- TODO - Make this editable with a knob -->
-			</UseTemplate>	
+			</UseTemplate>
 		</Component>
 		<Component ID="Radio_Right">
-			
+
 			<UseTemplate Name="ASOBO_GT_Component_Emissive_Gauge">
 				<NODE_ID>SCREEN_COM_R</NODE_ID>
 				<EMISSIVE_CODE>0.5</EMISSIVE_CODE> <!-- TODO - Make this editable with a knob -->
-			</UseTemplate>	
+			</UseTemplate>
 		</Component>
 		<Component ID="Switching_Panel">
 			<UseTemplate Name="ASOBO_GT_Anim">
@@ -2363,7 +2363,7 @@
 			<NODE_ID>PUSH_AUTOPILOT_MASTERAWARN_L</NODE_ID>
 			<NODE_ID_SEQ1>PUSH_AUTOPILOT_MASTERAWARN_L_SEQ1</NODE_ID_SEQ1>
 			<NODE_ID_SEQ2>PUSH_AUTOPILOT_MASTERAWARN_L_SEQ2</NODE_ID_SEQ2>
-			<ANIM_NAME>PUSH_AUTOPILOT_MASTERAWARN_L</ANIM_NAME>		
+			<ANIM_NAME>PUSH_AUTOPILOT_MASTERAWARN_L</ANIM_NAME>
 			<AIRBUS_TYPE/>
 			<NO_SEQ2/>
 		</UseTemplate>
@@ -2373,7 +2373,7 @@
 			<NODE_ID>PUSH_AUTOPILOT_MASTERCAUT_L</NODE_ID>
 			<NODE_ID_SEQ1>PUSH_AUTOPILOT_MASTERCAUT_L_SEQ1</NODE_ID_SEQ1>
 			<NODE_ID_SEQ2>PUSH_AUTOPILOT_MASTERCAUT_L_SEQ2</NODE_ID_SEQ2>
-			<ANIM_NAME>PUSH_AUTOPILOT_MASTERCAUT_L</ANIM_NAME>	
+			<ANIM_NAME>PUSH_AUTOPILOT_MASTERCAUT_L</ANIM_NAME>
 			<AIRBUS_TYPE/>
 			<NO_SEQ2/>
 		</UseTemplate>
@@ -2383,9 +2383,9 @@
 			<NODE_ID>PUSH_AUTOPILOT_MASTERAWARN_R</NODE_ID>
 			<NODE_ID_SEQ1>PUSH_AUTOPILOT_MASTERAWARN_R_SEQ1</NODE_ID_SEQ1>
 			<NODE_ID_SEQ2>PUSH_AUTOPILOT_MASTERAWARN_R_SEQ2</NODE_ID_SEQ2>
-			<ANIM_NAME>PUSH_AUTOPILOT_MASTERAWARN_R</ANIM_NAME>		
-			<AIRBUS_TYPE/>	
-			<NO_SEQ2/>	
+			<ANIM_NAME>PUSH_AUTOPILOT_MASTERAWARN_R</ANIM_NAME>
+			<AIRBUS_TYPE/>
+			<NO_SEQ2/>
 		</UseTemplate>
 		<UseTemplate Name="ASOBO_SAFETY_Push_Caution_Template">
 			<VAR_SCOPE>L</VAR_SCOPE>
@@ -2393,12 +2393,12 @@
 			<NODE_ID>PUSH_AUTOPILOT_MASTERCAUT_R</NODE_ID>
 			<NODE_ID_SEQ1>PUSH_AUTOPILOT_MASTERCAUT_R_SEQ1</NODE_ID_SEQ1>
 			<NODE_ID_SEQ2>PUSH_AUTOPILOT_MASTERCAUT_R_SEQ2</NODE_ID_SEQ2>
-			<ANIM_NAME>PUSH_AUTOPILOT_MASTERCAUT_R</ANIM_NAME>	
+			<ANIM_NAME>PUSH_AUTOPILOT_MASTERCAUT_R</ANIM_NAME>
 			<AIRBUS_TYPE/>
 			<NO_SEQ2/>
 		</UseTemplate>
 	</Component>
-	
+
 	<Component ID="DUMMY_ELEMENTS_SETUP_ANIM_STATE">
 		<UseTemplate Name="ASOBO_GT_Anim_Setup">
 			<ANIM_NAME>KNOB_ATC_THRT</ANIM_NAME>
@@ -2409,7 +2409,7 @@
 			<PERCENT>100</PERCENT>
 		</UseTemplate>
 	</Component>
-	
+
 	<Component ID="INOP">
 		<UseTemplate Name="ASOBO_GT_Interaction_Tooltip">
 			<NODE_ID>PUSH_AUTOPILOT_HDGTRK</NODE_ID>
@@ -3320,5 +3320,5 @@
 			<NODE_ID>PUSH_OVHD_ELT_ON</NODE_ID>
 		</UseTemplate>
 	</Component>
-	
+
 </ModelBehaviors>

--- a/A32NX/layout.json
+++ b/A32NX/layout.json
@@ -47,7 +47,7 @@
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml",
-            "size": 133460,
+            "size": 133075,
             "date": "132402817714110148"
         },
         {


### PR DESCRIPTION
EXCLUSIVE_AP case removed. AP1 and AP2 will now display as engaged at the same time and used already baked-in logic to simulate simultaneous AP1+AP2.