### PR TITLE
Activate both AP1 and AP2 at the same time

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml
@@ -1999,7 +1999,7 @@
 			<EMISSIVE_NODE_ID>PUSH_AUTOPILOT_AP1_SEQ2</EMISSIVE_NODE_ID>
 			<ID>1</ID>
 			<AP_COUNT>2</AP_COUNT>
-			<TYPE>EXCLUSIVE_AP</TYPE>
+			<!-- <TYPE>EXCLUSIVE_AP</TYPE> -->
 		</UseTemplate>
 		
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_Autopilot_Template">
@@ -2010,7 +2010,7 @@
 			<EMISSIVE_NODE_ID>PUSH_AUTOPILOT_AP2_SEQ2</EMISSIVE_NODE_ID>
 			<ID>2</ID>
 			<AP_COUNT>2</AP_COUNT>
-			<TYPE>EXCLUSIVE_AP</TYPE>
+			<!-- <TYPE>EXCLUSIVE_AP</TYPE> -->
 		</UseTemplate>
 		
 		<UseTemplate Name="ASOBO_AUTOPILOT_Push_AutoThrottle_Template">

--- a/A32NX/layout.json
+++ b/A32NX/layout.json
@@ -47,7 +47,7 @@
         },
         {
             "path": "SimObjects/AirPlanes/Asobo_A320_NEO/model/A320_NEO_INTERIOR.xml",
-            "size": 133460,
+            "size": 133478,
             "date": "132402817714110148"
         },
         {


### PR DESCRIPTION
EXCLUSIVE_AP case removed. AP1 and AP2 will now display as engaged at the same time and used already baked-in logic to simulate simultaneous AP1+AP2.