### PR TITLE
Changed "IRS IN ALIGN" to "IR IN ALIGN"

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.xml
@@ -204,7 +204,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 1 MN</Text>
+			<Text>IR IN ALIGN 1 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -221,7 +221,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 2 MN</Text>
+			<Text>IR IN ALIGN 2 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -238,7 +238,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 3 MN</Text>
+			<Text>IR IN ALIGN 3 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -255,7 +255,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 4 MN</Text>
+			<Text>IR IN ALIGN 4 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -272,7 +272,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 5 MN</Text>
+			<Text>IR IN ALIGN 5 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -289,7 +289,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 6 MN</Text>
+			<Text>IR IN ALIGN 6 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -306,7 +306,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 7 MN</Text>
+			<Text>IR IN ALIGN 7 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -323,7 +323,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 8 MN</Text>
+			<Text>IR IN ALIGN 8 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -340,7 +340,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 9 MN</Text>
+			<Text>IR IN ALIGN 9 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -357,7 +357,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 10 MN</Text>
+			<Text>IR IN ALIGN 10 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -374,7 +374,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 11 MN</Text>
+			<Text>IR IN ALIGN 11 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -391,7 +391,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 12 MN</Text>
+			<Text>IR IN ALIGN 12 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -408,7 +408,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 13 MN</Text>
+			<Text>IR IN ALIGN 13 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -425,7 +425,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 14 MN</Text>
+			<Text>IR IN ALIGN 14 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -442,7 +442,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN 15 MN</Text>
+			<Text>IR IN ALIGN 15 MN</Text>
 			<Condition>
 				<And>
 					<Greater>
@@ -459,7 +459,7 @@
 
 		<Annunciation>
 			<Type>Advisory</Type>
-			<Text>IRS IN ALIGN &gt; 15 MN</Text>
+			<Text>IR IN ALIGN &gt; 15 MN</Text>
 			<Condition>
 				<And>
 					<Greater>


### PR DESCRIPTION
In the real aircraft, the message shows "IR IN ALIGN" instead of the current "IRS IN ALIGN".