### PR TITLE
show NO SMOKING on ECAM memo when set to AUTO

### DIFF
--- a/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.xml
+++ b/A32NX/SimObjects/AirPlanes/Asobo_A320_NEO/panel/panel.xml
@@ -482,10 +482,30 @@
 		  <Type>Advisory</Type>
 		  <Text>NO SMOKING</Text>
 		  <Condition>
-            <Equal>
-			  <Simvar name="L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_Position" unit="Position"/>
-              <Constant>0.0</Constant>
-            </Equal>
+		  	<Or>
+				<Equal>
+					<Simvar name="L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_Position" unit="Position"/>
+					<Constant>0.0</Constant>
+				</Equal>
+				<And>
+					<Equal>
+						<Simvar name="L:XMLVAR_SWITCH_OVHD_INTLT_NOSMOKING_Position" unit="Position"/>
+						<Constant>1.0</Constant>
+					</Equal>
+					<Greater>
+						<Simvar name="GEAR RIGHT POSITION" unit="Percent"/>
+						<Constant>50</Constant>
+					</Greater>
+					<Greater>
+						<Simvar name="GEAR CENTER POSITION" unit="Percent"/>
+						<Constant>50</Constant>
+					</Greater>
+					<Greater>
+						<Simvar name="GEAR LEFT POSITION" unit="Percent"/>
+						<Constant>50</Constant>
+					</Greater>
+				</And>
+			</Or>
 		  </Condition>
 		</Annunciation>
 


### PR DESCRIPTION
fixes #237 

Makes it so NO SMOKING will appear on ECAM memo when set to AUTO and landing gear is more than 50% down.