### PR TITLE
Fixed altitude selection requiring to be clicked every time the altitude is updated.

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/FCU/A320_Neo_FCU.js
@@ -322,6 +322,19 @@ class A320_Neo_FCU_Altitude extends A320_Neo_FCU_Component {
             var value = Math.floor(Math.max(this.currentValue, 100));
             this.textValueContent = value.toString().padStart(5, "0");
             this.setElementVisibility(this.illuminator, this.isManaged);
+			if (!_isManaged) {
+				if ((Simplane.getAutoPilotAltitudeSelected() || Simplane.getAutoPilotAltitudeArmed()) && (Simplane.getAutoPilotFlightDirectorActive(1) || Simplane.getAutoPilotFlightDirectorActive(2)) && (Simplane.getAutoPilotActive(1)|| Simplane.getAutoPilotActive(2))) {
+					let targetAltitude = Simplane.getAutoPilotAltitudeLockValue("feets");
+					let altitude = Simplane.getAltitude();
+					if (altitude > targetAltitude + 100 || altitude < targetAltitude - 100) {
+						if (!Simplane.getAutoPilotGlideslopeHold()) {
+							SimVar.SetSimVarValue("L:A320_NEO_FCU_FORCE_IDLE_VS", "Number", 1);
+						}
+						Coherent.call("AP_ALT_VAR_SET_ENGLISH", 1, Simplane.getAutoPilotDisplayedAltitudeLockValue(), true);
+						SimVar.SetSimVarValue("K:ALTITUDE_SLOT_INDEX_SET", "number", 1);
+					}
+				}
+			}
         }
     }
 }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
@@ -1313,7 +1313,7 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
             selectedAltitude = Simplane.getAutoPilotDisplayedAltitudeLockValue();
         }
         else {
-            selectedAltitude = Simplane.getAutoPilotAltitudeLockValue();
+            selectedAltitude = Simplane.getAutoPilotDisplayedAltitudeLockValue(Simplane.getAutoPilotAltitudeLockUnits());
         }
         this.updateGraduationScrolling(altitude);
         this.updateCursorScrolling(altitude);


### PR DESCRIPTION
Fixed altitude selection requiring to be clicked every time the altitude is updated.

Based on feedback from real pilots and engineers, it will now work as follows:
If in level flight, changing the altitude dial will adjust the visible target altitude on the PFD, but not start a climb until it is pressed.
If in a climb/descent, changing the altitude dial will adjust the visible target altitude on the PFD and adjust the target altitude of the climb/descent.