### PR TITLE
align PFD 18 and 28 seconds into alignment

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -698,7 +698,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             //Turn off ADIRS
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum", 0);
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_IN_ALIGN", "Bool", 0);
-            SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool", 0);
+            SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool", 0);
+            SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_ATT", "Bool", 0);
             ADIRSState = 0;
         }
 
@@ -706,7 +707,8 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             //Start ADIRS Alignment
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum", 1);
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_IN_ALIGN", "Bool", 1); // DELETE AFTER MCDU IRS INIT IS IMPLEMENTED
-            SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool", 0);
+            SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool", 0);
+            SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_ATT", "Bool", 0);
             ADIRSState = 1;
             let currentLatitude = SimVar.GetSimVarValue("GPS POSITION LAT", "degree latitude")
             ADIRSTimer = Math.abs(1.14 * currentLatitude) * 10; //ADIRS ALIGN TIME DEPENDING ON LATITUDE.
@@ -718,15 +720,20 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             if (ADIRSTimer > 0) {
                 ADIRSTimer -= deltaTime/1000;
                 SimVar.SetSimVarValue("L:A320_Neo_ADIRS_TIME", "Seconds", ADIRSTimer);
-                const pfdAlignTime = SimVar.GetSimVarValue("L:A32NX_Neo_ADIRS_START_TIME", "Seconds") * 0.6;
-                if (ADIRSTimer < pfdAlignTime && SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 0) {
-                    //PFD Alignment Completed
-                    SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool", 1);
+                const ADIRSTimerStartTime = SimVar.GetSimVarValue("L:A32NX_Neo_ADIRS_START_TIME", "Seconds");
+                const secondsIntoAlignment = ADIRSTimerStartTime - ADIRSTimer;
+                if (SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool") == 0 && secondsIntoAlignment > 18) {
+                    SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool", 1);
+                }
+                if (SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_ATT", "Bool") == 0 && secondsIntoAlignment > 28) {
+                    SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_ATT", "Bool", 1);
                 }
                 if (ADIRSTimer <= 0) {
                     //ADIRS Alignment Completed
                     SimVar.SetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum", 2);
                     SimVar.SetSimVarValue("L:A320_Neo_ADIRS_IN_ALIGN", "Bool", 0);
+                    SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool", 1);
+                    SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_ATT", "Bool", 1);
                 }
             }
             

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/CDU/A320_Neo_CDU_MainDisplay.js
@@ -698,6 +698,7 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             //Turn off ADIRS
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum", 0);
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_IN_ALIGN", "Bool", 0);
+            SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool", 0);
             ADIRSState = 0;
         }
 
@@ -705,16 +706,23 @@ class A320_Neo_CDU_MainDisplay extends FMCMainDisplay {
             //Start ADIRS Alignment
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum", 1);
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_IN_ALIGN", "Bool", 1); // DELETE AFTER MCDU IRS INIT IS IMPLEMENTED
+            SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool", 0);
             ADIRSState = 1;
             let currentLatitude = SimVar.GetSimVarValue("GPS POSITION LAT", "degree latitude")
             ADIRSTimer = Math.abs(1.14 * currentLatitude) * 10; //ADIRS ALIGN TIME DEPENDING ON LATITUDE.
             SimVar.SetSimVarValue("L:A320_Neo_ADIRS_TIME", "Seconds", ADIRSTimer);
+            SimVar.SetSimVarValue("L:A32NX_Neo_ADIRS_START_TIME", "Seconds", ADIRSTimer);
         }
 
         if (ADIRSState == 1 && SimVar.GetSimVarValue("L:A320_Neo_ADIRS_IN_ALIGN", "Bool") == 1) {
             if (ADIRSTimer > 0) {
                 ADIRSTimer -= deltaTime/1000;
                 SimVar.SetSimVarValue("L:A320_Neo_ADIRS_TIME", "Seconds", ADIRSTimer);
+                const pfdAlignTime = SimVar.GetSimVarValue("L:A32NX_Neo_ADIRS_START_TIME", "Seconds") * 0.6;
+                if (ADIRSTimer < pfdAlignTime && SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 0) {
+                    //PFD Alignment Completed
+                    SimVar.SetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool", 1);
+                }
                 if (ADIRSTimer <= 0) {
                     //ADIRS Alignment Completed
                     SimVar.SetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum", 2);

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -107,14 +107,19 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
         }
 
         var ADIRSState = SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum");
-        var PFDAligned = SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool");
+        var PFDAlignedFirst = SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool");
+        var PFDAlignedATT = SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_ATT", "Bool");
 
-        if (PFDAligned) {
-            this.attitudeFail.setAttribute("style", "display:none");
+        if (PFDAlignedFirst) {
             this.miscFail.setAttribute("style", "display:none");
         } else {
-            this.attitudeFail.setAttribute("style", "");
             this.miscFail.setAttribute("style", "");
+        }
+
+        if (PFDAlignedATT) {
+            this.attitudeFail.setAttribute("style", "display:none");
+        } else {
+            this.attitudeFail.setAttribute("style", "");
         }
 
         if (ADIRSState == 2) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/A320_Neo_PFD.js
@@ -107,11 +107,11 @@ class A320_Neo_PFD_MainPage extends NavSystemPage {
         }
 
         var ADIRSState = SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum");
+        var PFDAligned = SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool");
 
-        if (ADIRSState >= 1) {
+        if (PFDAligned) {
             this.attitudeFail.setAttribute("style", "display:none");
             this.miscFail.setAttribute("style", "display:none");
-            
         } else {
             this.attitudeFail.setAttribute("style", "");
             this.miscFail.setAttribute("style", "");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
@@ -2051,7 +2051,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
                         }
                         hideBluePointer = false;
                     }
-                    else if (SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum") >= 1) {
+                    else if (SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1) {
                         hideBlueText = false;
                     }
                     hudSpeed = blueAirspeed;
@@ -2217,7 +2217,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
     updateStrip(_strip, currentAirspeed, maxSpeed, _forceHide, _topToBottom) {
         if (_strip) {
             let hideStrip = true;
-            if (!(SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum") >= 1)) _forceHide = true;
+            if (!(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1)) _forceHide = true;
             if (!_forceHide) {
                 if (maxSpeed > this.graduationMinValue) {
                     let vPosY = this.valueToSvg(currentAirspeed, maxSpeed);
@@ -2240,7 +2240,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
     updateSpeedMarkers(currentAirspeed) {
         for (let i = 0; i < this.speedMarkers.length; i++) {
             this.speedMarkers[i].update(currentAirspeed);
-            if (!(SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum") >= 1)) {
+            if (!(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1)) {
                 this.speedMarkers[i].svg.setAttribute("style", "display:none");
             } else {
                 this.speedMarkers[i].svg.setAttribute("style", "");
@@ -2438,7 +2438,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
         }
     }
     updateFail() {
-        var failed = !(SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum") >= 1);
+        var failed = !(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1);
         if (!failed) {
             this.bg.setAttribute("stroke", "transparent");
             this.topLine.setAttribute("stroke", "white");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AirspeedIndicator.js
@@ -2051,7 +2051,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
                         }
                         hideBluePointer = false;
                     }
-                    else if (SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1) {
+                    else if (SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool") == 1) {
                         hideBlueText = false;
                     }
                     hudSpeed = blueAirspeed;
@@ -2217,7 +2217,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
     updateStrip(_strip, currentAirspeed, maxSpeed, _forceHide, _topToBottom) {
         if (_strip) {
             let hideStrip = true;
-            if (!(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1)) _forceHide = true;
+            if (!(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool") == 1)) _forceHide = true;
             if (!_forceHide) {
                 if (maxSpeed > this.graduationMinValue) {
                     let vPosY = this.valueToSvg(currentAirspeed, maxSpeed);
@@ -2240,7 +2240,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
     updateSpeedMarkers(currentAirspeed) {
         for (let i = 0; i < this.speedMarkers.length; i++) {
             this.speedMarkers[i].update(currentAirspeed);
-            if (!(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1)) {
+            if (!(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool") == 1)) {
                 this.speedMarkers[i].svg.setAttribute("style", "display:none");
             } else {
                 this.speedMarkers[i].svg.setAttribute("style", "");
@@ -2438,7 +2438,7 @@ class Jet_PFD_AirspeedIndicator extends HTMLElement {
         }
     }
     updateFail() {
-        var failed = !(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1);
+        var failed = !(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool") == 1);
         if (!failed) {
             this.bg.setAttribute("stroke", "transparent");
             this.topLine.setAttribute("stroke", "white");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
@@ -1615,7 +1615,7 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
         }
     }
     updateFail() {
-        var failed = !(SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum") >= 1);
+        var failed = !(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1);
         if (!failed) {
             this.bg.setAttribute("stroke", "transparent");
             this.topLine.setAttribute("stroke", "white");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
@@ -1615,7 +1615,7 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
         }
     }
     updateFail() {
-        var failed = !(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1);
+        var failed = !(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool") == 1);
         if (!failed) {
             this.bg.setAttribute("stroke", "transparent");
             this.topLine.setAttribute("stroke", "white");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
@@ -1623,6 +1623,8 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
             this.cursorSVGShape.setAttribute("stroke", "white");
             this.cursorSVGMainText.setAttribute("visibility", "visible");
             this.pressureSVG.setAttribute("visibility", "visible");
+            this.targetAltitudeIndicatorSVGText.setAttribute("visibility", "visible");
+            this.targetAltitudeIndicatorSVG.setAttribute("visibility", "visible");
         } else {
             this.bg.setAttribute("stroke", "red");
             this.topLine.setAttribute("stroke", "red");
@@ -1633,6 +1635,8 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
             this.cursorSVGMainText.setAttribute("visibility", "hidden");
             if (this.targetAltitudeText) this.targetAltitudeText.textContent = "";
             this.pressureSVG.setAttribute("visibility", "hidden");
+            this.targetAltitudeIndicatorSVGText.setAttribute("visibility", "hidden");
+            this.targetAltitudeIndicatorSVG.setAttribute("visibility", "hidden");
         }
         if (this.groundRibbonSVGShape) this.groundRibbonSVG.setAttribute("style", failed ? "display:none" : "");
         if (this.cursorSVGScrollTexts) {
@@ -1640,7 +1644,7 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
                 st.setAttribute("visibility", failed ? "hidden" : "visible");
             }
         }
-        
+
         if (this.graduations != null) {
             for (let grad of this.graduations) {
                 grad.SVGLine.setAttribute("visibility", failed ? "hidden" : "visible");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/ILSIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/ILSIndicator.js
@@ -238,7 +238,7 @@ class Jet_PFD_ILSIndicator extends HTMLElement {
         this.appendChild(this.rootSVG);
     }
     update(_deltaTime) {
-        if (!this.gsVisible && SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 0) {
+        if (!this.gsVisible && SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool") == 0) {
             this.neutralLine.setAttribute("visibility", "hidden");
         } else {
             this.neutralLine.setAttribute("visibility", "visible");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/ILSIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/ILSIndicator.js
@@ -238,7 +238,7 @@ class Jet_PFD_ILSIndicator extends HTMLElement {
         this.appendChild(this.rootSVG);
     }
     update(_deltaTime) {
-        if (!this.gsVisible && SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Bool") == 0) {
+        if (!this.gsVisible && SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 0) {
             this.neutralLine.setAttribute("visibility", "hidden");
         } else {
             this.neutralLine.setAttribute("visibility", "visible");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
@@ -810,7 +810,7 @@ class Jet_PFD_VerticalSpeedIndicator extends HTMLElement {
         return height;
     }
     updateFail() {
-        var failed = !(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1);
+        var failed = !(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED_FIRST", "Bool") == 1);
         if (!failed) {
             this.failMask.setAttribute("visibility", "hidden");
             this.cursorSVGGroup.setAttribute("visibility", "visible");

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/VerticalSpeedIndicator.js
@@ -810,7 +810,7 @@ class Jet_PFD_VerticalSpeedIndicator extends HTMLElement {
         return height;
     }
     updateFail() {
-        var failed = !(SimVar.GetSimVarValue("L:A320_Neo_ADIRS_STATE", "Enum") >= 1);
+        var failed = !(SimVar.GetSimVarValue("L:A32NX_ADIRS_PFD_ALIGNED", "Bool") == 1);
         if (!failed) {
             this.failMask.setAttribute("visibility", "hidden");
             this.cursorSVGGroup.setAttribute("visibility", "visible");

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -1,1 +1,9 @@
 # A320neo Local SimVars
+
+- A32NX_ADIRS_PFD_ALIGNED
+    - Bool
+    - 0 when ADIRS is not aligned
+    - 1 when ADIRS is aligned or 3 minutes after it has started aligning
+- A32NX_Neo_ADIRS_START_TIME
+    - Holds the start time in seconds that the ADIRS TIMER will count down from
+    - Used to have certain things turn on based on a percentage of the total alignment time

--- a/docs/a320-simvars.md
+++ b/docs/a320-simvars.md
@@ -5,5 +5,6 @@
     - 0 when ADIRS is not aligned
     - 1 when ADIRS is aligned or 3 minutes after it has started aligning
 - A32NX_Neo_ADIRS_START_TIME
+    - Seconds
     - Holds the start time in seconds that the ADIRS TIMER will count down from
     - Used to have certain things turn on based on a percentage of the total alignment time


### PR DESCRIPTION
closes #147 

Ties PFD FAIL elements to the new local var L:A32NX_ADIRS_PFD_ALIGNED, so that PFD won't become available until 40% through alignment.