### PR TITLE
build: add .editorconfig

### DIFF
--- a/A32NX/.editorconfig
+++ b/A32NX/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 180
+tab_width = 4


### PR DESCRIPTION
This PR adds an [EditorConfig](https://editorconfig.org/) file.  This does not force anything, rather it provides a baseline encoding / formatting config for different text editors.

It can be used if desired by contributors, and optionally enforced later at the decision of the team.

Relates to / part of #212.