### PR TITLE
Updated FMA display of CAT 1,2,3 SINGLE & DUAL Capabilities

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -1481,15 +1481,17 @@ var Airbus_FMA;
             this.updateRow2(_deltaTime);
             this.updateRow3(_deltaTime);
         }
-        updateRow1(_deltaTime) {
+         updateRow1(_deltaTime) {
             var targetState = Column4.ROW_1_STATE.NONE;
-            if (Simplane.getAutoPilotAPPRActive() && Airbus_FMA.CurrentPlaneState.isILSApproachActive) {
-                if (Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
+            if (Airbus_FMA.CurrentPlaneState.autoPilotAPPRActive) {
+                if (Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive  && Airbus_FMA.CurrentPlaneState.isILSApproachActive && Airbus_FMA.CurrentPlaneState.autoPilotThrottleActive) { 
                     targetState = Column4.ROW_1_STATE.CAT_3;
                 }
-                else {
-                    targetState = Column4.ROW_1_STATE.CAT_1;
+                else if (!Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive  && Airbus_FMA.CurrentPlaneState.isILSApproachActive) {
+                    targetState = Column4.ROW_1_STATE.CAT_2;
                 }
+            } else if (Airbus_FMA.CurrentPlaneState.isILSApproachActive) {
+                targetState = Column4.ROW_1_STATE.CAT_1;
             }
             if (targetState != this.currentRow1State) {
                 this.currentRow1State = targetState;
@@ -1501,12 +1503,12 @@ var Airbus_FMA;
                         }
                     case Column4.ROW_1_STATE.CAT_2:
                         {
-                            this.setRowText(0, "CAT 2", Airbus_FMA.MODE_STATE.STATUS);
+                            this.setRowText(0, "CAT 2", Airbus_FMA.MODE_STATE.STATUS);//CAT 2: 1 AP, 0 A/T, 1FACs, 1 ELACs, 1 Y/D& RT, 2 HYD circuits, 1 FWC, 1 RA, 2 ADIRs
                             break;
                         }
                     case Column4.ROW_1_STATE.CAT_3:
                         {
-                            this.setRowText(0, "CAT 3", Airbus_FMA.MODE_STATE.STATUS);
+                            this.setRowText(0, "CAT 3", Airbus_FMA.MODE_STATE.STATUS); //CAT 3 SINGLE: 1 AP, 1 A/T, 1FACs, 1 ELACs, 1 Y/D& RT, 2 HYD circuits, 1 FWC, 2 RA, 2 ADIRs
                             break;
                         }
                     default:
@@ -1519,12 +1521,12 @@ var Airbus_FMA;
         }
         updateRow2(_deltaTime) {
             var targetState = Column4.ROW_2_STATE.NONE;
-            if (Simplane.getAutoPilotAPPRActive() && Airbus_FMA.CurrentPlaneState.isILSApproachActive && Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
-                if (Airbus_FMA.CurrentPlaneState.bothAutoPilotsActive) {
+            if (Airbus_FMA.CurrentPlaneState.autoPilotAPPRActive && Airbus_FMA.CurrentPlaneState.isILSApproachActive && Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
+                if (Airbus_FMA.CurrentPlaneState.bothAutoPilotsActive) { //CAT 3 DUAL: 2 AP, 2 A/T, 2FACs, 2 ELACs, 2 Y/D& RT, 3 HYD circuits, 2 FWC, 2 RA, 3 ADIRs
                     targetState = Column4.ROW_2_STATE.DUAL;
                 }
-                else if (Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
-                    targetState = Column4.ROW_2_STATE.SINGLE;
+                else if (Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) { 
+                    targetState = Column4.ROW_2_STATE.SINGLE; //CAT 3 SINGLE: 1 AP, 1 A/T, 1FACs, 1 ELACs, 1 Y/D& RT, 2 HYD circuits, 1 FWC, 2 RA, 2 ADIRs
                 }
             }
             if (targetState != this.currentRow2State) {

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -1527,7 +1527,7 @@ var Airbus_FMA;
         }
         updateRow2(_deltaTime) {
             var targetState = Column4.ROW_2_STATE.NONE;
-            if (isCAT3Capable == true) {
+            if (isCAT3Capable) {
                 if (Airbus_FMA.CurrentPlaneState.bothAutoPilotsActive) { //CAT 3 DUAL: 2 AP, 2 A/T, 2FACs, 2 ELACs, 2 Y/D& RT, 3 HYD circuits, 2 FWC, 2 RA, 3 ADIRs
                     targetState = Column4.ROW_2_STATE.DUAL;
                 }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -1481,17 +1481,23 @@ var Airbus_FMA;
             this.updateRow2(_deltaTime);
             this.updateRow3(_deltaTime);
         }
+	    
+	 var isCAT3Capable = false; // Is the A/C CAT3 Capable?
          updateRow1(_deltaTime) {
+
             var targetState = Column4.ROW_1_STATE.NONE;
-            if (Airbus_FMA.CurrentPlaneState.autoPilotAPPRActive) {
-                if (Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive  && Airbus_FMA.CurrentPlaneState.isILSApproachActive && Airbus_FMA.CurrentPlaneState.autoPilotThrottleActive) { 
+            if (Airbus_FMA.CurrentPlaneState.autoPilotAPPRActive && Airbus_FMA.CurrentPlaneState.isILSApproachActive && Airbus_FMA.CurrentPlaneState.radioAltitude <= 5000) { // below 5000 fT AGL
+                if (Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive && Airbus_FMA.CurrentPlaneState.autoPilotThrottleActive) { // At least One A/P and A/T
                     targetState = Column4.ROW_1_STATE.CAT_3;
+		    isCAT3Capable = true;	
                 }
-                else if (!Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive  && Airbus_FMA.CurrentPlaneState.isILSApproachActive) {
+                else if (!Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
                     targetState = Column4.ROW_1_STATE.CAT_2;
+		    isCAT3Capable = false;	
                 }
-            } else if (Airbus_FMA.CurrentPlaneState.isILSApproachActive) {
+            } else if (Airbus_FMA.CurrentPlaneState.autoPilotAPPRActive && Airbus_FMA.CurrentPlaneState.isILSApproachActive && Airbus_FMA.CurrentPlaneState.radioAltitude > 5000) {
                 targetState = Column4.ROW_1_STATE.CAT_1;
+		isCAT3Capable = false;	
             }
             if (targetState != this.currentRow1State) {
                 this.currentRow1State = targetState;
@@ -1521,7 +1527,7 @@ var Airbus_FMA;
         }
         updateRow2(_deltaTime) {
             var targetState = Column4.ROW_2_STATE.NONE;
-            if (Airbus_FMA.CurrentPlaneState.autoPilotAPPRActive && Airbus_FMA.CurrentPlaneState.isILSApproachActive && Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
+            if (isCAT3Capable == true) {
                 if (Airbus_FMA.CurrentPlaneState.bothAutoPilotsActive) { //CAT 3 DUAL: 2 AP, 2 A/T, 2FACs, 2 ELACs, 2 Y/D& RT, 3 HYD circuits, 2 FWC, 2 RA, 3 ADIRs
                     targetState = Column4.ROW_2_STATE.DUAL;
                 }

--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/Airbus_FMA.js
@@ -103,7 +103,7 @@ var Airbus_FMA;
             this.autoPilotActive[0] = Simplane.getAutoPilotActive(1);
             this.autoPilotActive[1] = Simplane.getAutoPilotActive(2);
             this.anyAutoPilotsActive = (this.autoPilotActive[0] || this.autoPilotActive[1]);
-            this.bothAutoPilotsActive = (this.autoPilotActive[0] && this.autoPilotActive[1]);
+	    this.onlyoneAutopilotActive = ((this.autoPilotActive[0] && !this.autoPilotActive[1]) || (!this.autoPilotActive[0] && this.autoPilotActive[1]));            this.bothAutoPilotsActive = (this.autoPilotActive[0] && this.autoPilotActive[1]);
             this.autoPilotFlightDirectorActive[0] = Simplane.getAutoPilotFlightDirectorActive(1);
             this.autoPilotFlightDirectorActive[1] = Simplane.getAutoPilotFlightDirectorActive(2);
             this.anyFlightDirectorsActive = (this.autoPilotFlightDirectorActive[0] || this.autoPilotFlightDirectorActive[1]);
@@ -1491,7 +1491,7 @@ var Airbus_FMA;
                     targetState = Column4.ROW_1_STATE.CAT_3;
 		    isCAT3Capable = true;	
                 }
-                else if (!Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) {
+                else if (!Airbus_FMA.CurrentPlaneState.onlyoneAutopilotActive) {
                     targetState = Column4.ROW_1_STATE.CAT_2;
 		    isCAT3Capable = false;	
                 }
@@ -1531,7 +1531,7 @@ var Airbus_FMA;
                 if (Airbus_FMA.CurrentPlaneState.bothAutoPilotsActive) { //CAT 3 DUAL: 2 AP, 2 A/T, 2FACs, 2 ELACs, 2 Y/D& RT, 3 HYD circuits, 2 FWC, 2 RA, 3 ADIRs
                     targetState = Column4.ROW_2_STATE.DUAL;
                 }
-                else if (Airbus_FMA.CurrentPlaneState.anyAutoPilotsActive) { 
+                else if (Airbus_FMA.CurrentPlaneState.onlyoneAutopilotActive) { 
                     targetState = Column4.ROW_2_STATE.SINGLE; //CAT 3 SINGLE: 1 AP, 1 A/T, 1FACs, 1 ELACs, 1 Y/D& RT, 2 HYD circuits, 1 FWC, 2 RA, 2 ADIRs
                 }
             }


### PR DESCRIPTION
According to my comments on PR #267 :

Modified UpdateRow1() and UpdateRow2() functions to reflect the actual capabilities of the A/C (Number of A/P engaged, A/THR engaged, and the like). 
What is displayed on the FMA is not related to actual weather conditions (CAT 1,2,3), but rather on required systems available for the approach.

Will be further refined later after implementation of some failures of critical systems that also affect the CAT capabilities display (example, 3 HYD circuits are needed to be operative for CAT 3 DUAL, only 2 for CAT 3 SINGLE).