### PR TITLE
fix target alt not going away on PFD

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/PFD/AltimeterIndicator.js
@@ -1623,8 +1623,6 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
             this.cursorSVGShape.setAttribute("stroke", "white");
             this.cursorSVGMainText.setAttribute("visibility", "visible");
             this.pressureSVG.setAttribute("visibility", "visible");
-            this.targetAltitudeIndicatorSVGText.setAttribute("visibility", "visible");
-            this.targetAltitudeIndicatorSVG.setAttribute("visibility", "visible");
         } else {
             this.bg.setAttribute("stroke", "red");
             this.topLine.setAttribute("stroke", "red");
@@ -1635,7 +1633,6 @@ class Jet_PFD_AltimeterIndicator extends HTMLElement {
             this.cursorSVGMainText.setAttribute("visibility", "hidden");
             if (this.targetAltitudeText) this.targetAltitudeText.textContent = "";
             this.pressureSVG.setAttribute("visibility", "hidden");
-            this.targetAltitudeIndicatorSVGText.setAttribute("visibility", "hidden");
             this.targetAltitudeIndicatorSVG.setAttribute("visibility", "hidden");
         }
         if (this.groundRibbonSVGShape) this.groundRibbonSVG.setAttribute("style", failed ? "display:none" : "");


### PR DESCRIPTION
Fixes #343 

Just needed to not do setVsiible on the target alt, since the main code will do that every frame anyways.

Before the updateFail code would force the selected altitude to be visible which is wrong.

tested spawning in apron and runway.