### PR TITLE
fix so ECAMs don't blank out after hitting APU MASTER

### DIFF
--- a/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
+++ b/A32NX/html_ui/Pages/VCockpit/Instruments/Airliners/A320_Neo/EICAS/A320_Neo_EICAS.js
@@ -129,13 +129,8 @@ class A320_Neo_EICAS extends Airliners.BaseEICAS {
 
         if (this.externalPowerWhenApuMasterOnTimer >= 0) {  
             this.externalPowerWhenApuMasterOnTimer -= _deltaTime/1000
-            this.electricity.style.display = "block";
-            this.electricity.style.opacity = 0;
-            this.changePage("APU");
             if (this.externalPowerWhenApuMasterOnTimer <= 0) {  
-                this.changePage("APU");
-                this.electricity.style.display = "none";
-                this.electricity.style.opacity = 1;
+                this.changePage("DOOR");
             }  
         }  
 


### PR DESCRIPTION
fixes #357

fix so ECAMs don't blank out after hitting APU MASTER with external power off
and so you aren't forced onto the APU page for 85 seconds
also puts you on DOOR page instead of APU page again after the 85 seconds is up
needs more work, but this fixes the major issues

CC: @ThePilot916